### PR TITLE
feat(electron): add offline action loading with custom paths

### DIFF
--- a/src/electron/load-action.js
+++ b/src/electron/load-action.js
@@ -5,11 +5,12 @@ const {app} = require('electron');
 /**
  * Loads a persisted action from the filesystem
  */
-module.exports = function loadAction(actionType) {
+module.exports = function loadAction(actionType, pathToFile) {
   const type = actionType.toLowerCase();
   const downloadsPath = app.getPath('downloads');
-  const actionsPath = path.join(downloadsPath, 'actions');
-  const filePath = path.join(actionsPath, type);
+  const filePath = pathToFile
+    ? path.join(downloadsPath, pathToFile)
+    : path.join(downloadsPath, 'actions', type);
 
   let action = null;
 

--- a/src/scripts/actions/fetch-layer.ts
+++ b/src/scripts/actions/fetch-layer.ts
@@ -15,12 +15,13 @@ export interface FetchLayerSuccessAction {
 
 interface FetchLayerErrorAction {
   type: typeof FETCH_LAYER_ERROR;
+  id: string;
   message: string;
 }
 
 export type FetchLayerActions = FetchLayerSuccessAction | FetchLayerErrorAction;
 
-function fetchLayerSuccessAction(id: string, layer: Layer) {
+export function fetchLayerSuccessAction(id: string, layer: Layer) {
   return {
     type: FETCH_LAYER_SUCCESS,
     id,
@@ -28,9 +29,10 @@ function fetchLayerSuccessAction(id: string, layer: Layer) {
   };
 }
 
-function fetchLayerErrorAction(message: string) {
+function fetchLayerErrorAction(id: string, message: string) {
   return {
     type: FETCH_LAYER_ERROR,
+    id,
     message
   };
 }
@@ -38,6 +40,6 @@ function fetchLayerErrorAction(message: string) {
 const fetchLayer = (id: string) => (dispatch: Dispatch) =>
   fetchLayerApi(id)
     .then(layer => dispatch(fetchLayerSuccessAction(id, layer)))
-    .catch(error => dispatch(fetchLayerErrorAction(error.message)));
+    .catch(error => dispatch(fetchLayerErrorAction(id, error.message)));
 
 export default fetchLayer;

--- a/src/scripts/components/app/app.tsx
+++ b/src/scripts/components/app/app.tsx
@@ -1,12 +1,8 @@
 import React, {FunctionComponent} from 'react';
-import {createStore, applyMiddleware, Middleware} from 'redux';
 import {Provider as StoreProvider, useSelector} from 'react-redux';
-import thunk from 'redux-thunk';
-import {createLogger} from 'redux-logger';
 import {IntlProvider} from 'react-intl';
 import {HashRouter as Router, Switch, Route, Redirect} from 'react-router-dom';
 
-import rootReducer from '../../reducers/index';
 import {languageSelector} from '../../selectors/language';
 import UrlSync from '../url-sync/url-sync';
 import LayerLoader from '../layer-loader/layer-loader';
@@ -17,43 +13,20 @@ import GlobeNavigation from '../globe-navigation/globe-navigation';
 import {EsaLogo} from '../icons/esa-logo';
 import TimeSlider from '../time-slider/time-slider';
 import DataSetInfo from '../data-set-info/data-set-info';
+import {createReduxStore} from './create-redux-store';
 
 import Story from '../story/story';
 import StoriesSelector from '../stories-selector/stories-selector';
 import PresentationSelector from '../presentation-selector/presentation-selector';
 import ShowcaseSelector from '../showcase-selector/showcase-selector';
 import Globes from '../globes/globes';
-import {
-  isElectron,
-  connectToStore,
-  offlineSaveMiddleware,
-  offlineLoadMiddleware
-} from '../../libs/electron/index';
 
 import translations from '../../i18n';
 
 import styles from './app.styl';
 
 // create redux store
-// @ts-ignore - injected by webpack
-const isProduction = PRODUCTION; // eslint-disable-line no-undef
-const middlewares: Middleware[] = [thunk];
-
-if (isElectron()) {
-  middlewares.push(offlineSaveMiddleware);
-  middlewares.push(offlineLoadMiddleware);
-}
-
-if (!isProduction || isElectron()) {
-  middlewares.push(createLogger({collapsed: true}));
-}
-
-const store = createStore(rootReducer, applyMiddleware(...middlewares));
-
-// connect electron messages to redux store
-if (isElectron()) {
-  connectToStore(store.dispatch);
-}
+const store = createReduxStore();
 
 const App: FunctionComponent = () => (
   <StoreProvider store={store}>

--- a/src/scripts/components/app/create-redux-store.ts
+++ b/src/scripts/components/app/create-redux-store.ts
@@ -1,0 +1,35 @@
+import {createStore, applyMiddleware, Middleware} from 'redux';
+import thunk from 'redux-thunk';
+import {createLogger} from 'redux-logger';
+
+import rootReducer from '../../reducers/index';
+import {
+  isElectron,
+  connectToStore,
+  offlineSaveMiddleware,
+  offlineLoadMiddleware
+} from '../../libs/electron/index';
+
+export function createReduxStore() {
+  // @ts-ignore - injected by webpack
+  const isProduction = PRODUCTION; // eslint-disable-line no-undef
+  const middlewares: Middleware[] = [thunk];
+
+  if (isElectron()) {
+    middlewares.push(offlineSaveMiddleware);
+    middlewares.push(offlineLoadMiddleware);
+  }
+
+  if (!isProduction || isElectron()) {
+    middlewares.push(createLogger({collapsed: true}));
+  }
+
+  const store = createStore(rootReducer, applyMiddleware(...middlewares));
+
+  // connect electron messages to redux store
+  if (isElectron()) {
+    connectToStore(store.dispatch);
+  }
+
+  return store;
+}

--- a/src/scripts/libs/electron/index.ts
+++ b/src/scripts/libs/electron/index.ts
@@ -9,7 +9,7 @@ declare global {
       downloadUrl: (url: string) => void;
       deleteId: (id: string) => void;
       saveAction: (action: Action) => void;
-      loadAction: (actionType: string) => Action | null;
+      loadAction: (actionType: string, filePath?: string) => Action | null;
       addIpcListener: (
         channel: string,
         callback: (event: {}, message: string) => void

--- a/src/scripts/libs/electron/load-action.ts
+++ b/src/scripts/libs/electron/load-action.ts
@@ -1,11 +1,14 @@
 import {Action} from 'redux';
 
 // Tries to load an action from the filesystem
-export function loadAction(actionType: string): Action | null {
+export function loadAction(
+  actionType: string,
+  filePath?: string
+): Action | null {
   if (!window.cfs) {
     console.error('Calling electron function from a non-electron environment');
     return null;
   }
 
-  return window.cfs.loadAction(actionType);
+  return window.cfs.loadAction(actionType, filePath);
 }

--- a/src/scripts/types/action-to-persist.ts
+++ b/src/scripts/types/action-to-persist.ts
@@ -1,7 +1,10 @@
+import {AnyAction} from 'redux';
+
 export interface ActionToPersist {
   success: string;
   error: string;
   save: boolean;
   load: boolean;
-  path?: string;
+  getFilePath?: (errorAction: AnyAction) => string;
+  successActionCreator?: (errorAction: AnyAction, content: any) => AnyAction;
 }


### PR DESCRIPTION
This adds the possibility to load offline actions from with different paths e.g. load the `FETCH_LAYERS` action content from the downloaded layers package instead of a previously written action file.  

Also moves the redux sore creation in a separate file to keep the `app.tsx` clean