### PR TITLE
feat(legend): add ability to hide legend

### DIFF
--- a/src/scripts/components/main/data-viewer/data-viewer.tsx
+++ b/src/scripts/components/main/data-viewer/data-viewer.tsx
@@ -148,25 +148,34 @@ const DataViewer: FunctionComponent<Props> = ({
     <div className={styles.dataViewer}>
       {[mainLayerDetails, compareLayerDetails]
         .filter((layer): layer is Layer => Boolean(layer))
-        .map(({id, maxValue, minValue, units, basemap, legendValues}, index) =>
-          id === 'land_cover.lccs_class' ? (
-            <HoverLegend
-              key={id}
-              values={legendValues as LegendValueColor[]}
-              isCompare={index > 0}
-            />
-          ) : (
-            <LayerLegend
-              key={id}
-              id={id}
-              values={
-                (legendValues as string[]) || [maxValue || 0, minValue || 0]
-              }
-              unit={units}
-              basemap={basemap}
-              isCompare={index > 0}
-            />
-          )
+        .map(
+          (
+            {id, maxValue, minValue, units, basemap, legendValues, hideLegend},
+            index
+          ) => {
+            if (hideLegend) {
+              return null;
+            }
+
+            return id === 'land_cover.lccs_class' ? (
+              <HoverLegend
+                key={id}
+                values={legendValues as LegendValueColor[]}
+                isCompare={index > 0}
+              />
+            ) : (
+              <LayerLegend
+                key={id}
+                id={id}
+                values={
+                  (legendValues as string[]) || [maxValue || 0, minValue || 0]
+                }
+                unit={units}
+                basemap={basemap}
+                isCompare={index > 0}
+              />
+            );
+          }
         )}
 
       {getDataWidget({

--- a/src/scripts/types/layer.d.ts
+++ b/src/scripts/types/layer.d.ts
@@ -22,4 +22,5 @@ export interface Layer {
   units: string;
   legendValues: string[] | LegendValueColor[];
   legendBackgroundColor: string;
+  hideLegend?: boolean;
 }


### PR DESCRIPTION
Adds the ability to hide the legend when `hideLegend: true` is set in the layers `metadata.json` file.