### PR TITLE
feat(pipeline): remove default value for extend

### DIFF
--- a/pipeline/dags/biomass.agb.py
+++ b/pipeline/dags/biomass.agb.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'biomass'
 LAYER_VARIABLE = 'agb'
 RESOLUTION = '81000 31500'
+EXTEND = '-180 -60 180 80'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -52,7 +53,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te='-180 -60 180 80', max_tis_warp=1, max_tis_dem=1, max_tis_translate=1)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND, max_tis_warp=1, max_tis_dem=1, max_tis_translate=1)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/cloud.cfc.py
+++ b/pipeline/dags/cloud.cfc.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'cloud'
 LAYER_VARIABLE = 'cfc'
 RESOLUTION = '1024 512'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -47,7 +48,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
     download = task_factories.gcs_download_file(bucket_name=BUCKET_ORIGIN, dir=WORKDIR, appendix='_downloaded')
     legend_image = task_factories.legend_image(workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
-    gdal_transforms = task_factories.gdal_transforms(layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+    gdal_transforms = task_factories.gdal_transforms(layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 
     # connect tasks

--- a/pipeline/dags/fire.burned_area.py
+++ b/pipeline/dags/fire.burned_area.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'fire'
 LAYER_VARIABLE = 'burned_area'
 RESOLUTION = '1440 720'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -57,7 +58,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/greenhouse_xch4.py
+++ b/pipeline/dags/greenhouse_xch4.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'greenhouse'
 LAYER_VARIABLE = 'xch4'
 RESOLUTION = '180 90'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -61,7 +62,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/greenhouse_xco2.py
+++ b/pipeline/dags/greenhouse_xco2.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'greenhouse'
 LAYER_VARIABLE = 'xco2'
 RESOLUTION = '180 90'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -61,7 +62,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/land_cover.lccs_class.py
+++ b/pipeline/dags/land_cover.lccs_class.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'land_cover'
 LAYER_VARIABLE = 'lccs_class'
 RESOLUTION = '64800 32400'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [], # will be injected
@@ -49,7 +50,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
     download = task_factories.gcs_download_file(bucket_name=BUCKET_ORIGIN, dir=WORKDIR, appendix='_downloaded')
     legend_image = task_factories.legend_image(workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
-    gdal_transforms = task_factories.gdal_transforms(layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, max_tis_warp=1, max_tis_dem=1, max_tis_translate=1)
+    gdal_transforms = task_factories.gdal_transforms(layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND, max_tis_warp=1, max_tis_dem=1, max_tis_translate=1)
     upload = task_factories.upload(WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 
     # connect tasks

--- a/pipeline/dags/land_surface_temperature.lst.py
+++ b/pipeline/dags/land_surface_temperature.lst.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'land_surface_temperature'
 LAYER_VARIABLE = 'lst'
 RESOLUTION = '1440 720'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -52,7 +53,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/oc.chlor_a.py
+++ b/pipeline/dags/oc.chlor_a.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'oc'
 LAYER_VARIABLE = 'chlor_a'
 RESOLUTION = '2048 1024'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -52,7 +53,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/sea_state_swh_mean.py
+++ b/pipeline/dags/sea_state_swh_mean.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'sea_state'
 LAYER_VARIABLE = 'swh_mean'
 RESOLUTION = '360 180'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -52,7 +53,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/soil_moisture.Anomaly.py
+++ b/pipeline/dags/soil_moisture.Anomaly.py
@@ -9,6 +9,7 @@ LAYER_ID = 'soil_moisture'
 LAYER_VARIABLE = 'Anomaly'
 LAYER_VERSION = '1.14.1'
 RESOLUTION = '1440 720'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "version": LAYER_VERSION,
@@ -54,7 +55,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/soil_moisture.sm.py
+++ b/pipeline/dags/soil_moisture.sm.py
@@ -8,6 +8,7 @@ from helper import get_default_layer_version
 LAYER_ID = 'soil_moisture'
 LAYER_VARIABLE = 'sm'
 RESOLUTION = '1440 720'
+EXTEND = '-180 -90 180 90'
 METADATA = {
     "id": f'{LAYER_ID}.{LAYER_VARIABLE}',
     "timestamps": [],  # will be injected
@@ -52,7 +53,7 @@ with DAG(dag_id=METADATA["id"], start_date=datetime(2022, 1, 1), schedule=None, 
         workdir=WORKDIR, color_file=COLOR_FILE)
     metadata = task_factories.metadata(workdir=WORKDIR, metadata=METADATA)
     gdal_transforms = task_factories.gdal_transforms(
-        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION)
+        layer_variable=LAYER_VARIABLE, color_file=COLOR_FILE, layer_type=METADATA['type'], zoom_levels=METADATA['zoom_levels'], gdal_ts=RESOLUTION, gdal_te=EXTEND)
     upload = task_factories.upload(
         WORKDIR, LAYER_ID, LAYER_VARIABLE, METADATA['type'])
 

--- a/pipeline/dags/task_factories.py
+++ b/pipeline/dags/task_factories.py
@@ -167,7 +167,7 @@ def gdal_transforms(color_file: str, layer_type: str, zoom_levels: str, gdal_te:
 
         return BashOperator.partial(
             task_id='gdal_translate_tiles',
-            bash_command=f'rm -rf $FILEPATH_OUT && gdal2tiles.py --profile geodetic --zoom={zoom_levels} --tmscompatible --no-kml --webviewer=none --resampling average --processes=16 --s_srs EPSG:4326 $FILEPATH_IN $FILEPATH_OUT && echo $FILEPATH_OUT',
+            bash_command=f'rm -rf $FILEPATH_OUT && gdal2tiles.py --profile geodetic --zoom={zoom_levels} --tmscompatible --no-kml --webviewer=none --resampling average --s_srs EPSG:4326 $FILEPATH_IN $FILEPATH_OUT && echo $FILEPATH_OUT',
             max_active_tis_per_dag=max_tis_translate
         )
 

--- a/pipeline/dags/task_factories.py
+++ b/pipeline/dags/task_factories.py
@@ -167,7 +167,7 @@ def gdal_transforms(color_file: str, layer_type: str, zoom_levels: str, gdal_te:
 
         return BashOperator.partial(
             task_id='gdal_translate_tiles',
-            bash_command=f'rm -rf $FILEPATH_OUT && gdal2tiles.py --profile geodetic --zoom={zoom_levels} --tmscompatible --exclude --no-kml --webviewer=none --resampling average --processes=16 --s_srs EPSG:4326 $FILEPATH_IN $FILEPATH_OUT && echo $FILEPATH_OUT',
+            bash_command=f'rm -rf $FILEPATH_OUT && gdal2tiles.py --profile geodetic --zoom={zoom_levels} --tmscompatible --no-kml --webviewer=none --resampling average --processes=16 --s_srs EPSG:4326 $FILEPATH_IN $FILEPATH_OUT && echo $FILEPATH_OUT',
             max_active_tis_per_dag=max_tis_translate
         )
 

--- a/pipeline/docker-compose.yaml
+++ b/pipeline/docker-compose.yaml
@@ -55,7 +55,6 @@ x-airflow-common: &airflow-common
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
-    AIRFLOW__CORE__MAX_ACTIVE_TASKS_PER_DAG: '1'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:


### PR DESCRIPTION
Default value for extend needs to be removed because we now have layers with selected regions that are not global. Global extend was moved to dag files if it needs to be set. I it's not set, extend of input netcdf file is used. Same behavior is now for resolution.