### PR TITLE
feat(layers-list): always use compare mode for layers

### DIFF
--- a/src/scripts/components/layers/layer-list-item/layer-list-item.module.css
+++ b/src/scripts/components/layers/layer-list-item/layer-list-item.module.css
@@ -20,6 +20,7 @@
 .layerItem:hover .compare,
 .layerItem:focus .compare {
   display: block;
+  color: var(--main);
 }
 .compare {
   display: none;
@@ -29,10 +30,6 @@
   text-transform: uppercase;
   font-size: 0.6875em;
   cursor: pointer;
-}
-.compare:hover,
-.compare:focus {
-  color: var(--main);
 }
 .layerTitle {
   display: flex;

--- a/src/scripts/components/layers/layer-list-item/layer-list-item.tsx
+++ b/src/scripts/components/layers/layer-list-item/layer-list-item.tsx
@@ -25,16 +25,10 @@ const LayerListItem: FunctionComponent<Props> = ({
   });
 
   return (
-    <div className={styles.layerItem} >
+    <div className={styles.layerItem} onClick={() => onSelect(layer.id, false)}>
       <span className={styles.layerTitle}>{layer.shortName}</span>
       {isMainSelected && (
-        <button
-          className={styles.compare}
-          onClick={(event) => {
-            onSelect(layer.id, false);
-            event.stopPropagation();
-          }}
-        >
+        <button className={styles.compare}>
           <FormattedMessage id={"layerSelector.compare"} />
         </button>
       )}

--- a/src/scripts/components/layers/selected-layer-list-item/selected-layer-list-item.tsx
+++ b/src/scripts/components/layers/selected-layer-list-item/selected-layer-list-item.tsx
@@ -1,4 +1,7 @@
 import { FunctionComponent } from "react";
+import { useSelector } from "react-redux";
+
+import { selectedLayerIdsSelector } from "../../../selectors/layers/selected-ids";
 
 import { RemoveIcon } from "../../main/icons/remove-icon";
 import { replaceUrlPlaceholders } from "../../../libs/replace-url-placeholders";
@@ -29,6 +32,8 @@ const SelectedLayerListItem: FunctionComponent<Props> = ({
   const layerIconUrl = replaceUrlPlaceholders(layerIconTemplate, {
     id: layer.id,
   });
+  const selectedLayerIds = useSelector(selectedLayerIdsSelector);
+  const { mainId } = selectedLayerIds;
 
   return (
     <div className={styles.selectedLayerListItem}>
@@ -36,7 +41,7 @@ const SelectedLayerListItem: FunctionComponent<Props> = ({
         <img src={layerIconUrl} className={styles.layerIcon} />
         <span className={styles.layerTitle}>{layer.shortName}</span>
       </div>
-      {!isCompareSelected && (
+      {!isCompareSelected && layer.id !== mainId && (
         <button className={styles.removeIcon} onClick={() => onRemove()}>
           <RemoveIcon />
         </button>


### PR DESCRIPTION
Hovering a list entry now always highlights compare button. Click selects layer for compare mode.

<img width="529" alt="image" src="https://github.com/user-attachments/assets/14d1f2cb-1c5d-44ea-8675-b3606fd2e9c9" />
