### PR TITLE
fix(marker-markup): decrease marker svg size

### DIFF
--- a/src/scripts/components/main/globe/globe.module.css
+++ b/src/scripts/components/main/globe/globe.module.css
@@ -27,6 +27,7 @@
   user-select: none;
   cursor: pointer;
   animation: pulse 1.5s ease-out;
+  margin: -16px;
 
   .outer {
     opacity: 0.3;

--- a/src/scripts/components/main/globe/marker-markup.tsx
+++ b/src/scripts/components/main/globe/marker-markup.tsx
@@ -13,13 +13,19 @@ export const MarkerMarkup: FunctionComponent<Props> = ({ title }) => {
       className={styles.marker}
       data-marker={title}
       xmlns="http://www.w3.org/2000/svg"
-      width="48"
-      height="48"
-      viewBox="0 0 48 48"
+      width="32"
+      height="32"
+      viewBox="0 0 32 32"
       fill="none"
     >
-      <circle cx="24" cy="24" r="10" stroke="var(--main)"   className={styles.outer} />
-      <circle cx="24" cy="24" r="4" fill="var(--main)" />
+      <circle
+        cx="16"
+        cy="16"
+        r="10"
+        stroke="var(--main)"
+        className={styles.outer}
+      />
+      <circle cx="16" cy="16" r="4" fill="var(--main)" />
     </svg>
   );
 };


### PR DESCRIPTION
closes #1683

Before
<img width="248" alt="image" src="https://github.com/user-attachments/assets/90580757-ce8d-4861-af78-661470782911" />
Now
<img width="262" alt="image" src="https://github.com/user-attachments/assets/cc8518d5-c8b8-4534-bda6-46de210e8883" />

