### PR TITLE
feat(story-image): attach caption to image on fullscreen

### DIFF
--- a/src/scripts/components/stories/caption/caption.module.css
+++ b/src/scripts/components/stories/caption/caption.module.css
@@ -1,9 +1,6 @@
 .caption {
-  position: absolute;
-  bottom: 0;
   box-sizing: border-box;
   padding-right: 3.4375em;
-  padding-bottom: 2.5em;
   min-height: var(--story-caption-height);
   width: 100%;
   background: rgba(16, 22, 26, 0.6);
@@ -18,6 +15,9 @@
   -webkit-box-orient: vertical;
 }
 .lightboxCaption {
+  position: absolute;
+  bottom: 0;
+  padding-bottom: 2.5em;
   overflow: hidden;
   padding: 1.5em 0.9375em;
   pointer-events: none;
@@ -32,6 +32,12 @@
 }
 
 @media screen and (--mobile-s-viewport) {
+  .caption {
+    position: absolute;
+    bottom: 0;
+    padding-bottom: 2.5em;
+  }
+
   .content {
     -webkit-line-clamp: 3;
   }

--- a/src/scripts/components/stories/caption/caption.tsx
+++ b/src/scripts/components/stories/caption/caption.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from "react";
 import ReactMarkdown from "react-markdown";
 import cx from "classnames";
+import { useScreenSize } from "../../../hooks/use-screen-size";
 
 import styles from "./caption.module.css";
 import { ImageFit } from "../../../types/image-fit";
@@ -16,13 +17,17 @@ const Caption: FunctionComponent<Props> = ({
   showLightbox,
   imageFit,
 }) => {
+  const { isMobile } = useScreenSize();
   const classes = cx(styles.caption, showLightbox && styles.lightboxCaption);
 
   return (
     <div
       className={classes}
       style={{
-        position: imageFit === ImageFit.Cover ? "absolute" : "static",
+        position:
+          (showLightbox || isMobile) && imageFit === ImageFit.Cover
+            ? "absolute"
+            : "static",
       }}
     >
       <div className={styles.content}>

--- a/src/scripts/components/stories/story-gallery-item/story-gallery-item.module.css
+++ b/src/scripts/components/stories/story-gallery-item/story-gallery-item.module.css
@@ -29,13 +29,13 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   width: 100%;
   height: 100%;
 }
 .photo {
-  flex: 1;
-  width: 100%;
-  height: 0;
+  flex: 0;
+  height: auto;
 }
 .transition {
   transition: transform ease-out 0.5s;
@@ -56,6 +56,11 @@
     overflow: hidden;
     padding: 0;
     max-width: 100%;
+  }
+  .photo {
+    flex: 1;
+    width: 100%;
+    height: 0;
   }
   .lightboxStoryGallery .photo {
     flex: 0;

--- a/src/scripts/components/stories/story-gallery-item/story-gallery-item.module.css
+++ b/src/scripts/components/stories/story-gallery-item/story-gallery-item.module.css
@@ -57,4 +57,8 @@
     padding: 0;
     max-width: 100%;
   }
+  .lightboxStoryGallery .photo {
+    flex: 0;
+    height: auto;
+  }
 }

--- a/src/scripts/components/stories/story-image/story-image.module.css
+++ b/src/scripts/components/stories/story-image/story-image.module.css
@@ -3,3 +3,10 @@
   width: 100%;
   height: 0;
 }
+
+@media screen and (--mobile-viewport) {
+  .lightboxPhoto {
+    flex: 0;
+    height: auto;
+  }
+}

--- a/src/scripts/components/stories/story-image/story-image.module.css
+++ b/src/scripts/components/stories/story-image/story-image.module.css
@@ -1,10 +1,20 @@
 .photo {
-  flex: 1;
+  flex: 0;
   width: 100%;
+  height: auto;
+}
+
+.lightboxPhoto {
+  flex: 1;
   height: 0;
 }
 
 @media screen and (--mobile-viewport) {
+  .photo {
+    flex: 1;
+    height: 0;
+  }
+
   .lightboxPhoto {
     flex: 0;
     height: auto;

--- a/src/scripts/components/stories/story-image/story-image.tsx
+++ b/src/scripts/components/stories/story-image/story-image.tsx
@@ -1,4 +1,6 @@
 import { FunctionComponent } from "react";
+import cx from "classnames";
+
 import { getStoryAssetUrl } from "../../../libs/get-story-asset-urls";
 
 import Caption from "../caption/caption";
@@ -24,7 +26,7 @@ const StoryImage: FunctionComponent<Props> = ({
   return (
     <>
       <img
-        className={styles.photo}
+        className={cx(styles.photo, showLightbox && styles.lightboxPhoto)}
         style={{
           objectFit: imageFit === ImageFit.Cover ? "cover" : "contain",
         }}


### PR DESCRIPTION
for #1776

Before
<img width="452" alt="image" src="https://github.com/user-attachments/assets/cd713317-834d-4a2b-bc42-3b55163c49bb" />

Now
<img width="450" alt="image" src="https://github.com/user-attachments/assets/f9a6dbe3-0df0-46f2-82d5-8e25027a15b4" />
