### PR TITLE
Feat/replace module with dialog

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -23,7 +23,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <div id="modal"></div>
     <script type="module" src="/scripts/index.tsx"></script>
   </body>
 </html>

--- a/src/scripts/components/main/header/header.module.css
+++ b/src/scripts/components/main/header/header.module.css
@@ -6,7 +6,6 @@
   flex-wrap: no-wrap;
   justify-content: space-between;
   gap: 0.5rem;
-  z-index: 10;
   grid-area: header;
   padding: 0 1.5rem;
 

--- a/src/scripts/components/main/header/header.tsx
+++ b/src/scripts/components/main/header/header.tsx
@@ -94,7 +94,7 @@ const Header: FunctionComponent = () => {
             className={styles.button}
             id="ui-menu"
             icon={MenuIcon}
-            name={"app_menu"}
+            ariaLabel={"app_menu"}
             onClick={() => setShowMenu(true)}
             hideLabelOnMobile
           />

--- a/src/scripts/components/main/overlay/overlay.module.css
+++ b/src/scripts/components/main/overlay/overlay.module.css
@@ -1,25 +1,37 @@
 .overlay {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 11;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
+  /* overwrite dialog default */
+  margin: auto;
+  max-height: 100%;
+  max-width: 100%;
   width: 100%;
   height: 100%;
-  background-color: rgba(16,22,26,0.9);
-}
-.overlayContent {
-  display: flex;
-  justify-content: center;
+  overflow: auto;
+  pointer-events: auto;
   align-items: center;
-  width: 100%;
-  height: 70%;
+  background-color: transparent;
+  border: none;
+  color: inherit;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  padding: 0;
 }
+
+.overlay::backdrop {
+  background-color: rgba(16, 22, 26, 0.9);
+}
+
+.overlayContent {
+  color: white;
+  align-items: center;
+  display: flex;
+  height: 70%;
+  justify-content: center;
+  width: 100%;
+}
+
 .closeButton {
   position: absolute;
-  top: 1rem;
   right: 1.5rem;
+  top: 1rem;
 }

--- a/src/scripts/components/main/overlay/overlay.tsx
+++ b/src/scripts/components/main/overlay/overlay.tsx
@@ -1,5 +1,4 @@
-import { FunctionComponent } from "react";
-import { createPortal } from "react-dom";
+import { FunctionComponent, useEffect, useRef } from "react";
 import cx from "classnames";
 
 import Button from "../button/button";
@@ -20,46 +19,30 @@ const Overlay: FunctionComponent<Props> = ({
   onClose,
   showCloseButton = true,
 }) => {
-  const modalElement = document.getElementById("modal");
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // Trigger dialog visibility upon initial rendering
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog) {
+      dialog.showModal();
+    }
+  }, []);
+
   const classes = cx(styles.overlay, className);
 
-  // stops progation when overlay is present
-  // This is useful because otherwise the user would also
-  // control the gesture-based navigation and interfere with the overlay
-  const stopPropagation = (e: React.SyntheticEvent) => {
-    e.stopPropagation();
-  };
-
-  const Content = (
-    <div
-      className={classes}
-      onWheel={stopPropagation}
-      onMouseDown={stopPropagation}
-      onTouchStart={stopPropagation}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          if (onClose) { onClose(); }
-        }
-      }}
-      role="button"
-      tabIndex={0}
-    >
+  return (
+    <dialog ref={dialogRef} className={classes} onClose={onClose}>
       {showCloseButton && (
         <Button
           icon={CloseIcon}
           className={styles.closeButton}
-          onClick={() => onClose && onClose()}
+          onClick={() => dialogRef.current?.close()}
         />
       )}
       <div className={styles.overlayContent}>{children}</div>
-    </div>
+    </dialog>
   );
-
-  if (modalElement) {
-    return createPortal(Content, modalElement);
-  }
-
-  return null;
 };
 
 export default Overlay;

--- a/src/scripts/components/main/overlay/overlay.tsx
+++ b/src/scripts/components/main/overlay/overlay.tsx
@@ -40,7 +40,7 @@ const Overlay: FunctionComponent<Props> = ({
           onClick={() => dialogRef.current?.close()}
         />
       )}
-      <div className={styles.overlayContent}>{children}</div>
+      <div className={styles.overlayContent} onWheel={(e) => e.stopPropagation()}>{children}</div>
     </dialog>
   );
 };


### PR DESCRIPTION
for #1665 

- replace the `module` div with a `dialog` element
- this 
1. cleans up the DOM
2. prevents `z-Index` issue as the dialog is always rendered in the top layer
3. has much better accessibility out-of-the-box 