### PR TITLE
refactor(data-widget): create local and global state data widget

### DIFF
--- a/src/scripts/components/layers/time-playback/time-playback.ts
+++ b/src/scripts/components/layers/time-playback/time-playback.ts
@@ -1,17 +1,17 @@
 import { FunctionComponent, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
-import { timeSelector } from "../../../selectors/globe/time";
 import { layerLoadingStateSelector } from "../../../selectors/globe/layer-loading-state";
 
 import { useInterval } from "../../../hooks/use-interval";
 import { LayerLoadingState } from "@ubilabs/esa-webgl-globe";
-import { setGlobeTime } from "../../../reducers/globe/time";
 
 const PLAYBACK_STEP = 1000 * 60 * 60 * 24 * 30; // one month
 const PLAYBACK_SPEED = 1000; // increase one step per x milliseconds
 
 interface Props {
+  time: number;
+  setGlobeTime: (time: number) => void;
   minTime: number;
   maxTime: number;
   speed?: number;
@@ -21,6 +21,8 @@ interface Props {
 }
 
 const TimePlayback: FunctionComponent<Props> = ({
+  time,
+  setGlobeTime,
   minTime,
   maxTime,
   speed = PLAYBACK_SPEED,
@@ -28,9 +30,6 @@ const TimePlayback: FunctionComponent<Props> = ({
   mainLayerId,
   compareLayerId,
 }) => {
-  const dispatch = useDispatch();
-  const time = useSelector(timeSelector);
-
   const [nextTime, setNextTime] = useState(time);
   const [stepIndex, setStepIndex] = useState(() => {
     const index = steps.findIndex((step) => step >= time);
@@ -86,8 +85,8 @@ const TimePlayback: FunctionComponent<Props> = ({
       return;
     }
 
-    dispatch(setGlobeTime(nextTime));
-  }, [dispatch, time, nextTime, mainLayerState, compareLayerState]);
+    setGlobeTime(nextTime);
+  }, [time, nextTime, mainLayerState, compareLayerState, setGlobeTime]);
 
   return null;
 };

--- a/src/scripts/components/layers/time-slider/time-slider.tsx
+++ b/src/scripts/components/layers/time-slider/time-slider.tsx
@@ -3,16 +3,14 @@ import {
   useState,
   useMemo,
   useEffect,
-  useCallback,
+  useEffectEvent,
 } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { FormattedDate } from "react-intl";
 import debounce from "lodash.debounce";
 import cx from "classnames";
 
-import { timeSelector } from "../../../selectors/globe/time";
 import { layerDetailsSelector } from "../../../selectors/layers/layer-details";
-import { setGlobeTime } from "../../../reducers/globe/time";
 import { State } from "../../../reducers";
 import getPlaybackStep from "../../../libs/get-playback-step";
 import clampToRange from "../../../libs/clamp-to-range";
@@ -31,7 +29,8 @@ interface Props {
   className?: string;
   mainId: string | null;
   compareId: string | null;
-  time?: number;
+  time: number;
+  setGlobeTime: (time: number) => void;
   noTimeClamp?: boolean;
   autoplay?: boolean;
 }
@@ -43,12 +42,13 @@ const TimeSlider: FunctionComponent<Props> = ({
   className = "",
   mainId,
   compareId,
+  time: propsTime,
+  setGlobeTime,
   noTimeClamp,
   autoplay = false,
 }) => {
   const dispatch = useDispatch();
-  const globeTime = useSelector(timeSelector);
-  const [time, setTime] = useState(globeTime);
+  const [time, setTime] = useState(propsTime);
   const [isPlaying, setIsPlaying] = useState(false);
   const stepSize = 1000 * 60 * 60 * 24; // one day
   const mainLayerDetails = useSelector((state: State) =>
@@ -81,38 +81,41 @@ const TimeSlider: FunctionComponent<Props> = ({
     combined,
     timeIndexMain,
     timeIndexCompare,
-  } = useLayerTimes(mainId, compareId);
+  } = useLayerTimes(time, mainId, compareId);
 
   const clampedTime = clampToRange(time, combined.min, combined.max);
 
   // update app state
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedSetGlobeTime = useCallback(
-    debounce((newTime: number) => dispatch(setGlobeTime(newTime)), DELAY, {
+  const debouncedSetGlobeTime = useMemo(
+    () => debounce((newTime: number) => setGlobeTime(newTime), DELAY, {
       maxWait: DELAY,
     }),
-    [],
+    [setGlobeTime],
   );
 
   // clamp globe time to min/max of the active layers when a layer changes
   // dont clamp in story mode where time is set by slide
   useEffect(() => {
     if (!noTimeClamp && clampedTime !== time) {
-      dispatch(setGlobeTime(clampedTime));
+      setGlobeTime(clampedTime);
     }
-  }, [noTimeClamp, clampedTime, time, dispatch]);
+  }, [noTimeClamp, clampedTime, time, setGlobeTime]);
+
+  const togglePlayback = useEffectEvent((autoplay: boolean) => setIsPlaying(autoplay));
 
   // stop playback when layer changes
   useEffect(() => {
-    setIsPlaying(autoplay);
+    togglePlayback(autoplay);
   }, [mainLayerDetails, compareLayerDetails, autoplay]);
+
+  const syncLocalTime = useEffectEvent((time: number) => setTime(time));
 
   // sync local time
   useEffect(() => {
-    if (time !== globeTime) {
-      setTime(globeTime);
+    if (time !== propsTime) {
+      syncLocalTime(propsTime);
     }
-  }, [time, globeTime]);
+  }, [time, propsTime]);
 
   // stop globe spinning when playing
   useEffect(() => {
@@ -142,6 +145,8 @@ const TimeSlider: FunctionComponent<Props> = ({
     <div className={classes}>
       {isPlaying && (
         <TimePlayback
+          time={time}
+          setGlobeTime={setGlobeTime}
           minTime={combined.min}
           maxTime={combined.max}
           steps={playbackSteps}

--- a/src/scripts/components/main/data-viewer/data-viewer.tsx
+++ b/src/scripts/components/main/data-viewer/data-viewer.tsx
@@ -23,9 +23,9 @@ import {
 
 import ContentNavigation from "../content-navigation/content-navigation";
 import Button from "../button/button";
-import { GetDataWidget } from "../data-widget/data-widget";
 import CategoryNavigation from "../category-navigation/category-navigation";
 import GlobeNavigation from "../globe-navigation/globe-navigation";
+import { GetGlobalDataWidget } from "../data-widget/global-data-widget";
 import { BackButton } from "../back-button/back-button";
 
 import styles from "./data-viewer.module.css";
@@ -119,7 +119,7 @@ const DataViewer: FunctionComponent = () => {
           isContentNavRoute && styles.showContentList,
         )}
       >
-        <GetDataWidget className={cx(styles.globe)} />
+        <GetGlobalDataWidget className={cx(styles.globe)} />
       </div>
       {isDataRoute && <GlobeNavigation />}
       {isNavigationView && (

--- a/src/scripts/components/main/data-widget/data-widget.tsx
+++ b/src/scripts/components/main/data-widget/data-widget.tsx
@@ -6,102 +6,83 @@ import {
   useLayoutEffect,
   useState,
 } from "react";
+import { useSelector } from "react-redux";
 
 import { CameraView } from "@ubilabs/esa-webgl-globe";
-import { useDispatch, useSelector } from "react-redux";
 import { useMatomo } from "@streamr/matomo-tracker-react";
 
 import { embedElementsSelector } from "../../../selectors/embed-elements-selector";
 import { contentSelector } from "../../../selectors/content";
-import { flyToSelector } from "../../../selectors/fly-to";
-import { globeSpinningSelector } from "../../../selectors/globe/spinning";
-import { globeViewSelector } from "../../../selectors/globe/view";
 import { languageSelector } from "../../../selectors/language";
 import { layerDetailsSelector } from "../../../selectors/layers/layer-details";
 import { layerListItemSelector } from "../../../selectors/layers/list-item";
-import { selectedLayerIdsSelector } from "../../../selectors/layers/selected-ids";
 import { projectionSelector } from "../../../selectors/globe/projection";
-import { timeSelector } from "../../../selectors/globe/time";
 
-import { updateLayerLoadingState } from "../../../reducers/globe/layer-loading-state";
-import { setGlobeSpinning } from "../../../reducers/globe/spinning";
-import { setGlobeView } from "../../../reducers/globe/view";
 import { State } from "../../../reducers";
 
 import { useContentMarker } from "../../../hooks/use-story-markers";
 import { useGetLayerListQuery, useGetLayerQuery } from "../../../services/api";
 import { useImageLayerData } from "../../../hooks/use-image-layer-data";
 import { useAppRouteFlags } from "../../../hooks/use-app-route-flags";
-import { flyToToCameraView } from "../../../hooks/use-story-globe";
 
 import { GlobeImageLayerData } from "../../../types/globe-image-layer-data";
 import { LayerType } from "../../../types/globe-layer-type";
 import { LegendValueColor } from "../../../types/legend-value-color";
 import { Layer } from "../../../types/layer";
 import { GlobeItem } from "../../../types/gallery-item";
-
 import { LayerLoadingStateChangeHandle } from "../data-viewer/data-viewer";
+
 import Gallery from "../gallery/gallery";
 import Globe from "../globe/globe";
 import HoverLegend from "../../layers/hover-legend/hover-legend";
 import LayerLegend from "../../layers/layer-legend/layer-legend";
 import DataSetInfo from "../../layers/data-set-info/data-set-info";
 import TimeSlider from "../../layers/time-slider/time-slider";
+
 interface Props {
   globeItem?: GlobeItem;
   className?: string;
   showMarkers?: boolean;
   autoplay?: boolean;
   touchable?: boolean;
+  globeView: CameraView;
+  mainId: string | null;
+  compareId: string | null;
+  time: number;
+  setGlobeTime: (time: number) => void;
+  globeSpinning: boolean;
+  flyTo: CameraView | null;
+  onMoveStartHandler: () => void;
+  onMoveEndHandler: (view: CameraView) => void;
+  onLayerLoadingStateChangeHandler: LayerLoadingStateChangeHandle;
 }
 
 export const GetDataWidget: FunctionComponent<Props> = ({
-  globeItem,
   className,
   showMarkers = true,
   autoplay = false,
   touchable = true,
+  globeView,
+  mainId,
+  compareId,
+  time,
+  setGlobeTime,
+  globeSpinning,
+  flyTo,
+  onMoveStartHandler,
+  onMoveEndHandler,
+  onLayerLoadingStateChangeHandler,
 }) => {
   const projectionState = useSelector(projectionSelector);
-  const globalGlobeView = useSelector(globeViewSelector);
-  const globeSpinning = useSelector(globeSpinningSelector);
-  const [currentView, setCurrentView] = useState(globalGlobeView);
-  const [flyToState, setFlyToState] = useState(
-    globeItem?.flyTo ? flyToToCameraView(globeItem.flyTo) : null,
-  );
-  const flyTo = useSelector(flyToSelector);
+
+  const [currentView, setCurrentView] = useState(globeView);
+
   const [isMainActive, setIsMainActive] = useState(true);
   const { trackEvent } = useMatomo();
 
-  const language = useSelector(languageSelector);
-  const dispatch = useDispatch();
-  const time = useSelector(timeSelector);
-
-  const selectedLayerIds = useSelector(selectedLayerIdsSelector);
-  let { mainId, compareId } = selectedLayerIds;
-
   const { isContentNavRoute, isStoriesRoute, isDataRoute } = useAppRouteFlags();
 
-  // If globeItem is provided, it takes precedence over the selected layer IDs and flyTo in the store.
-  // This allows us to use the GetDataWidget component in different contexts, such as in stories where
-  // we want to apply specific globe items without affecting the global state of selected layers and
-  // flyTo for other parts of the app.
-  if (globeItem) {
-    const [mainLayer, compareLayer] = globeItem?.layer || [];
-    mainId = mainLayer?.id || mainId;
-    compareId = compareLayer?.id || compareId;
-  }
-
-  // Update flyToState if it is not already set via globeItem
-  const flyToEvent = useEffectEvent(() => {
-    if (!flyToState || !globeItem) {
-      setFlyToState(flyTo);
-    }
-  });
-
-  useEffect(() => {
-    flyToEvent();
-  }, [flyTo, globeItem]);
+  const language = useSelector(languageSelector);
 
   const mainLayerDetails = useSelector((state: State) =>
     layerDetailsSelector(state, mainId),
@@ -148,23 +129,6 @@ export const GetDataWidget: FunctionComponent<Props> = ({
     onDatasetChange();
   }, [mainId, compareId, isDataRoute]);
 
-  const onMoveStartHandler = useCallback(
-    () => globeSpinning && dispatch(setGlobeSpinning(false)),
-    [dispatch, globeSpinning],
-  );
-
-  const onMoveEndHandler = useCallback(
-    (view: CameraView) => dispatch(setGlobeView(view)),
-    [dispatch],
-  );
-
-  const onLayerLoadingStateChangeHandler: LayerLoadingStateChangeHandle =
-    useCallback(
-      (layerId, loadingState) =>
-        dispatch(updateLayerLoadingState({ layerId, loadingState })),
-      [dispatch],
-    );
-
   const selectedContentId = useSelector(contentSelector).contentId;
 
   const contentMarker = useContentMarker(selectedContentId ?? null, language);
@@ -209,8 +173,8 @@ export const GetDataWidget: FunctionComponent<Props> = ({
   // we don't use the app state view all the time to keep store updates low
   useLayoutEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setCurrentView(globalGlobeView);
-  }, [globalGlobeView]);
+    setCurrentView(globeView);
+  }, [globeView]);
 
   const onChangeHandler = useCallback((view: CameraView) => {
     setCurrentView(view);
@@ -222,13 +186,6 @@ export const GetDataWidget: FunctionComponent<Props> = ({
 
   const { legend, time_slider } = useSelector(embedElementsSelector);
 
-  // stop globe spinning when layer is selected
-  useEffect(() => {
-    if ((mainId || compareId) && globeSpinning) {
-      dispatch(setGlobeSpinning(false));
-    }
-  }, [dispatch, mainId, compareId, globeSpinning]);
-
   // Shared props for Globe instances
   const globeProps = {
     ...(showMarkers && contentMarker && { markers: [contentMarker] }),
@@ -238,7 +195,7 @@ export const GetDataWidget: FunctionComponent<Props> = ({
     view: currentView,
     projectionState,
     spinning: globeSpinning,
-    flyTo: flyToState,
+    flyTo,
     onChange: onChangeHandler,
     onMoveStart: onMoveStartHandler,
     onMoveEnd: onMoveEndHandler,
@@ -255,8 +212,10 @@ export const GetDataWidget: FunctionComponent<Props> = ({
         <>
           {!isStoriesRoute && <DataSetInfo />}
           {legend && getLegends()}
-          {time_slider && touchable && (
+          {time_slider && (
             <TimeSlider
+              time={time}
+              setGlobeTime={setGlobeTime}
               mainId={mainId}
               compareId={compareId}
               noTimeClamp={isStoriesRoute}

--- a/src/scripts/components/main/data-widget/global-data-widget.tsx
+++ b/src/scripts/components/main/data-widget/global-data-widget.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { CameraView } from "@ubilabs/esa-webgl-globe";
+
+import { setGlobeSpinning } from "../../../reducers/globe/spinning";
+import { setGlobeTime } from "../../../reducers/globe/time";
+import { setGlobeView } from "../../../reducers/globe/view";
+import { updateLayerLoadingState } from "../../../reducers/globe/layer-loading-state";
+import { flyToSelector } from "../../../selectors/fly-to";
+import { globeSpinningSelector } from "../../../selectors/globe/spinning";
+import { timeSelector } from "../../../selectors/globe/time";
+import { globeViewSelector } from "../../../selectors/globe/view";
+import { selectedLayerIdsSelector } from "../../../selectors/layers/selected-ids";
+
+import { LayerLoadingStateChangeHandle } from "../data-viewer/data-viewer";
+
+import { GetDataWidget } from "./data-widget";
+
+interface Props {
+  className?: string;
+}
+
+export const GetGlobalDataWidget = ({ className }: Props) => {
+  const globalGlobeView = useSelector(globeViewSelector);
+  const globeSpinning = useSelector(globeSpinningSelector);
+
+  const flyTo = useSelector(flyToSelector);
+
+  const dispatch = useDispatch();
+  const time = useSelector(timeSelector);
+
+  const selectedLayerIds = useSelector(selectedLayerIdsSelector);
+  const { mainId, compareId } = selectedLayerIds;
+
+  const onMoveStartHandler = useCallback(
+    () => globeSpinning && dispatch(setGlobeSpinning(false)),
+    [dispatch, globeSpinning],
+  );
+
+  const onMoveEndHandler = useCallback(
+    (view: CameraView) => dispatch(setGlobeView(view)),
+    [dispatch],
+  );
+
+  const onLayerLoadingStateChangeHandler: LayerLoadingStateChangeHandle =
+    useCallback(
+      (layerId, loadingState) =>
+        dispatch(updateLayerLoadingState({ layerId, loadingState })),
+      [dispatch],
+    );
+
+  // stop globe spinning when layer is selected
+  useEffect(() => {
+    if ((mainId || compareId) && globeSpinning) {
+      dispatch(setGlobeSpinning(false));
+    }
+  }, [dispatch, mainId, compareId, globeSpinning]);
+
+  const handleSetGlobeTime = useCallback(
+    (time: number) => dispatch(setGlobeTime(time)),
+    [dispatch],
+  );
+
+  return (
+    <GetDataWidget 
+      className={className}
+      globeView={globalGlobeView}
+      mainId={mainId}
+      compareId={compareId}
+      time={time}
+      setGlobeTime={handleSetGlobeTime}
+      globeSpinning={globeSpinning}
+      flyTo={flyTo}
+      onMoveStartHandler={onMoveStartHandler}
+      onMoveEndHandler={onMoveEndHandler}
+      onLayerLoadingStateChangeHandler={onLayerLoadingStateChangeHandler}
+    />
+  );
+};

--- a/src/scripts/components/main/data-widget/local-data-widget.tsx
+++ b/src/scripts/components/main/data-widget/local-data-widget.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+
+import { flyToToCameraView } from "../../../hooks/use-story-globe";
+
+import { GlobeItem } from "../../../types/gallery-item";
+
+import { GetDataWidget } from "./data-widget";
+
+interface Props {
+  className?: string;
+  autoplay?: boolean;
+  touchable?: boolean;
+  globeItem: GlobeItem;
+}
+
+export const GetLocalDataWidget = ({
+  className,
+  globeItem,
+  autoplay,
+  touchable,
+}: Props) => {
+  const { layer } = globeItem;
+
+  const [mainLayer, compareLayer] = layer || [];
+
+  const mainId = mainLayer?.id ?? null;
+  const compareId = compareLayer?.id ?? null;
+
+  const [globeTime, setGlobeTime] = useState(
+    mainLayer?.timestamp ? new Date(mainLayer.timestamp).getTime() : 0,
+  );
+  const flyTo = globeItem.flyTo;
+  const cameraView = flyToToCameraView(flyTo);
+
+  return (
+    <GetDataWidget
+      className={className}
+      mainId={mainId}
+      compareId={compareId}
+      time={globeTime}
+      setGlobeTime={setGlobeTime}
+      flyTo={cameraView}
+      globeView={cameraView}
+      globeSpinning={false}
+      showMarkers={false}
+      autoplay={autoplay}
+      touchable={touchable}
+      onMoveStartHandler={() => {}}
+      onMoveEndHandler={() => {}}
+      onLayerLoadingStateChangeHandler={() => {}}
+    />
+  );
+};

--- a/src/scripts/components/main/globe-compare-layer/globe-compare-layer.tsx
+++ b/src/scripts/components/main/globe-compare-layer/globe-compare-layer.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from "react";
-import { GetDataWidget } from "../data-widget/data-widget";
 import { GlobeItem } from "../../../types/gallery-item";
+import { GetLocalDataWidget } from "../data-widget/local-data-widget";
 
 interface Props {
   className?: string;
@@ -15,11 +15,14 @@ export const GlobeCompareLayer: FunctionComponent<Props> = ({
   touchable = true,
   globeItem,
 }) => {
+  if (!globeItem) {
+    return null;
+  }
+
   return (
-    <GetDataWidget
+    <GetLocalDataWidget
       className={className}
       globeItem={globeItem}
-      showMarkers={false}
       autoplay={autoplay}
       touchable={touchable}
     />

--- a/src/scripts/components/main/globe-navigation/globe-navigation.tsx
+++ b/src/scripts/components/main/globe-navigation/globe-navigation.tsx
@@ -7,6 +7,7 @@ import config from "../../../config/main";
 import { useLayerTimes } from "../../../hooks/use-formatted-time";
 import { downloadScreenshot } from "../../../libs/download-screenshot";
 import { projectionSelector } from "../../../selectors/globe/projection";
+import { timeSelector } from "../../../selectors/globe/time";
 import Button from "../button/button";
 import { CompassIcon } from "../icons/compass-icon";
 import { DownloadIcon } from "../icons/download-icon";
@@ -29,7 +30,8 @@ const GlobeNavigation: FunctionComponent = () => {
   const projectionState = useSelector(projectionSelector);
   const label =
     projectionState.projection === GlobeProjection.Sphere ? "2D" : "3D";
-  const { mainTimeFormat, compareTimeFormat } = useLayerTimes();
+  const time = useSelector(timeSelector);
+  const { mainTimeFormat, compareTimeFormat } = useLayerTimes(time, null, null);
 
   const selectedLayerIds = useSelector(selectedLayerIdsSelector);
   const { mainId, compareId } = selectedLayerIds;

--- a/src/scripts/hooks/use-formatted-time.ts
+++ b/src/scripts/hooks/use-formatted-time.ts
@@ -3,15 +3,13 @@ import { useSelector } from "react-redux";
 import { getLayerTimeIndex } from "../libs/get-image-layer-data";
 import { getTimeRanges } from "../libs/get-time-ranges";
 import { State } from "../reducers";
-import { timeSelector } from "../selectors/globe/time";
 import { languageSelector } from "../selectors/language";
 import { layerDetailsSelector } from "../selectors/layers/layer-details";
 import { selectedLayerIdsSelector } from "../selectors/layers/selected-ids";
 
-export const useLayerTimes = (mainLayerId: string | null, compareLayerId: string | null) => {
+export const useLayerTimes = (time: number, mainLayerId: string | null, compareLayerId: string | null) => {
   const language = useSelector(languageSelector);
   const selectedLayerIds = useSelector(selectedLayerIdsSelector);
-  const time = useSelector(timeSelector);
   let { mainId, compareId } = selectedLayerIds;
   if (mainLayerId) {
     mainId = mainLayerId;


### PR DESCRIPTION
closes #2081

Global and local state where still mixed up in `DataWidget`. Therefore I now created `GlobalDataWidget` providing globe with global state and `LocalDataWidget` using only local state for globe within stories.