### PR TITLE
fix(route): correctly route legacy url to data view

### DIFF
--- a/src/scripts/components/main/header/header.tsx
+++ b/src/scripts/components/main/header/header.tsx
@@ -56,9 +56,8 @@ const Header: FunctionComponent = () => {
   const { isMobile, isDesktop } = useScreenInfo();
   const appRoute = useSelector(appRouteSelector);
 
-  const { header, logo, back_link, app_menu, layers_menu } = useSelector(
-    embedElementsSelector,
-  );
+  const { header, stories_menu, logo, back_link, app_menu, layers_menu } =
+    useSelector(embedElementsSelector);
 
   const isLayerSelectorVisible = useSelector(showLayerSelector);
 
@@ -67,7 +66,7 @@ const Header: FunctionComponent = () => {
 
   const isSearchActive = Boolean(location.state?.search);
 
-  if (!header) {
+  if (!header || !stories_menu) {
     // The app element determines the layout via grid which is why we should return a DOM element here
     // set css custom property --header-height to 0
     document.documentElement.style.setProperty("--header-height", "0px");

--- a/src/scripts/hooks/use-globe-route-state.ts
+++ b/src/scripts/hooks/use-globe-route-state.ts
@@ -42,7 +42,7 @@ export function useGlobeRouteState(globe: WebGlGlobe | null) {
 
   const redirectLegacyLayerUrl = useCallback(() => {
     const layerId = mainId;
-    if (layerId && !layers?.length) {
+    if (layerId && !layers) {
       return true;
     }
 

--- a/src/scripts/hooks/use-globe-route-state.ts
+++ b/src/scripts/hooks/use-globe-route-state.ts
@@ -40,6 +40,10 @@ export function useGlobeRouteState(globe: WebGlGlobe | null) {
   const language = useSelector(languageSelector);
   const { data: layers } = useGetLayerListQuery(language);
 
+  // we check if on the main route is layer is present and re-route that request to layer/data
+  // This structure is used on climate.esa.int website to embed data layers
+  // see e.g. https://climate.esa.int/en/projects/land-surface-temperature/
+  // we need to ensure compatibility for those urls
   const redirectLegacyLayerUrl = useCallback(() => {
     const layerId = mainId;
     if (layerId && !layers) {

--- a/src/scripts/hooks/use-globe-route-state.ts
+++ b/src/scripts/hooks/use-globe-route-state.ts
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { WebGlGlobe } from "@ubilabs/esa-webgl-globe";
 
@@ -30,6 +30,7 @@ import { useGetLayerListQuery } from "../services/api";
  */
 export function useGlobeRouteState(globe: WebGlGlobe | null) {
   const navigate = useNavigate();
+  const location = useLocation();
   const dispatch = useDispatch();
   const appRoute = useSelector(appRouteSelector);
   const previousPathnameRef = useRef<string | null>(null);
@@ -38,6 +39,28 @@ export function useGlobeRouteState(globe: WebGlGlobe | null) {
   const { mainId } = selectedLayerIds;
   const language = useSelector(languageSelector);
   const { data: layers } = useGetLayerListQuery(language);
+
+  const redirectLegacyLayerUrl = useCallback(() => {
+    const layerId = mainId;
+    if (layerId && !layers?.length) {
+      return true;
+    }
+
+    const layer = layers?.find((layer) => layer.id === layerId);
+    if (layer && layer.categories?.length) {
+      dispatch(setSelectedLayerIds({ layerId, isPrimary: true }));
+      navigate(
+        {
+          pathname: `/${layer.categories[0]}/data`,
+          search: location.search,
+        },
+        { replace: true },
+      );
+      return true;
+    }
+
+    return false;
+  }, [dispatch, layers, location.search, mainId, navigate]);
 
   const updateAutoRotationState = useCallback(
     (shouldAutoSpin: boolean) => {
@@ -76,11 +99,8 @@ export function useGlobeRouteState(globe: WebGlGlobe | null) {
         // On initial load, attempt to select the data layer specified via URL parameters.
         // This ensures backward compatibility with CfS versions prior to 2.0.
         if (!previousPathnameRef.current) {
-          const layerId = selectedLayerIds?.mainId;
-          const layer = layers?.find((layer) => layer.id === layerId);
-          if (layer && layer.categories?.length) {
-            dispatch(setSelectedLayerIds({ layerId, isPrimary: true }));
-            navigate(`/${layer.categories[0]}/data`);
+          if (redirectLegacyLayerUrl()) {
+            return;
           }
           break;
         }
@@ -100,6 +120,16 @@ export function useGlobeRouteState(globe: WebGlGlobe | null) {
         break;
 
       case AppRoute.NavContent:
+        if (
+          !previousPathnameRef.current &&
+          // Some legacy embed links use /index.html as the hash route. React Router
+          // matches that as a content category, so handle it like the root route here.
+          location.pathname === "/index.html" &&
+          redirectLegacyLayerUrl()
+        ) {
+          return;
+        }
+
         dispatch(setShowLayer(false));
         dispatch(setSelectedLayerIds({ layerId: null, isPrimary: false }));
         break;
@@ -130,7 +160,17 @@ export function useGlobeRouteState(globe: WebGlGlobe | null) {
 
     // Store the current pathname for next comparison
     previousPathnameRef.current = appRoute;
-  }, [appRoute, dispatch, layers, mainId, navigate, selectedLayerIds?.mainId]);
+  }, [
+    appRoute,
+    dispatch,
+    layers,
+    location.search,
+    location.pathname,
+    mainId,
+    navigate,
+    redirectLegacyLayerUrl,
+    selectedLayerIds?.mainId,
+  ]);
 
   // Update globe states based on route changes
   useEffect(() => {

--- a/src/scripts/reducers/embed-elements.ts
+++ b/src/scripts/reducers/embed-elements.ts
@@ -10,6 +10,7 @@ const initialState: EmbedElementsState = {
   layers_menu: parseUrl("layers_menu") ?? true,
   legend: parseUrl("legend") ?? true,
   header: parseUrl("header") ?? true,
+  stories_menu: parseUrl("stories_menu") ?? true,
   back_link: parseUrl("back_link") ?? true,
   app_menu: parseUrl("app_menu") ?? true,
   lng: parseLngUrl() ?? "",

--- a/src/scripts/types/embed-elements.ts
+++ b/src/scripts/types/embed-elements.ts
@@ -3,6 +3,7 @@ export interface EmbedElementsState {
   time_slider?: boolean;
   legend?: boolean;
   header?: boolean;
+  stories_menu?: boolean;
   back_link?: boolean;
   app_menu?: boolean;
   layers_menu?: boolean;


### PR DESCRIPTION
  - correctly routes legacy routes embedding data sets from esa website, e.g.
  https://climate.esa.int/en/projects/land-surface-temperature/
  - restores url param `stories_menu`