### PR TITLE
add chapter progress indicator for stories

### DIFF
--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
@@ -18,7 +18,6 @@
     list-style-type: none;
     height: 100%;
     justify-content: center;
-    anchor-name: --dot-container;
     place-items: start center;
 
     @media screen and (--desktop-viewport) {

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
@@ -10,6 +10,7 @@
 
   .dotContainer {
     --dot-size: 10px;
+    --dot-color: var(--neutral-esa-white);
     list-style-type: none;
     height: 100%;
     display: grid;
@@ -18,15 +19,15 @@
     anchor-name: --dot-container;
 
     .activeIndicator {
-      width: 20px;
-      height: 20px;
+      --indicator-size: calc(anchor-size(width, 100%) * 2);
+      --indicator-ring-offset: calc(var(--dot-size) * 0.8);
+      width: var(--indicator-size);
+      height: var(--indicator-size);
       display: inline-block;
-      background-color: red;
+      background-color: var(--dot-color);
       box-sizing: border-box;
       position: absolute;
-      position-anchor: --dot-4;
-      position-area: center;
-      clip-path: circle(40%);
+      position-area: center center;
       border-radius: 50%;
     }
 
@@ -36,9 +37,22 @@
       width: var(--dot-size);
       height: var(--dot-size);
       border-radius: 50%;
-      background-color: white;
       display: inline-block;
-      background-color: var(--neutral-esa-white);
+      background-color: var(--dot-color);
+
+      .dotButton {
+        all: unset;
+        display: block;
+        width: 100%;
+        height: 100%;
+        border-radius: inherit;
+        cursor: pointer;
+
+        &:focus-visible {
+          outline: 2px solid var(--neutral-esa-white);
+          outline-offset: 3px;
+        }
+      }
 
       &:after {
         width: 1px;

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
@@ -1,0 +1,41 @@
+.chapterIndicator {
+  --header-offset: calc(var(--header-height) / 2);
+
+  z-index: 3;
+  position: fixed;
+  height: calc(var(--story-height) - 25%);
+  width: 20px;
+  top: calc(50% + var(--header-offset));
+  transform: translate(36px, -50%);
+
+  .dotContainer {
+    list-style-type: none;
+    height: 100%;
+    display: grid;
+    align-content: space-between;
+    justify-content: center;
+    anchor-name: --dot-container;
+
+    > li.dot {
+      --dot-size: 9px;
+      --divider-space: 1rem;
+      display: inline-block;
+      width: var(--dot-size);
+      height: var(--dot-size);
+      background-color: white;
+      border-radius: 100px;
+
+      &:after {
+        width: 1px;
+        background-color: grey;
+        content: "";
+        position: absolute;
+        transform: translateX(-50%);
+        width: 2px;
+        inset-block-start: var(--anchor-start);
+        inset-block-end: var(--anchor-end);
+        inset-inline: anchor(--dot-container center);
+      }
+    }
+  }
+}

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
@@ -4,11 +4,12 @@
   z-index: 3;
   position: fixed;
   height: calc(var(--story-height) - 25%);
-  width: 20px;
+  width: 24px;
   top: calc(50% + var(--header-offset));
   transform: translate(36px, -50%);
 
   .dotContainer {
+    --dot-size: 10px;
     list-style-type: none;
     height: 100%;
     display: grid;
@@ -16,25 +17,37 @@
     justify-content: center;
     anchor-name: --dot-container;
 
+    .activeIndicator {
+      width: 20px;
+      height: 20px;
+      display: inline-block;
+      background-color: red;
+      box-sizing: border-box;
+      position: absolute;
+      position-anchor: --dot-4;
+      position-area: center;
+      clip-path: circle(40%);
+      border-radius: 50%;
+    }
+
     > li.dot {
-      --dot-size: 9px;
-      --divider-space: 1rem;
+      --line-offset: min(6px, 6vh);
       display: inline-block;
       width: var(--dot-size);
       height: var(--dot-size);
+      border-radius: 50%;
       background-color: white;
-      border-radius: 100px;
+      display: inline-block;
+      background-color: var(--neutral-esa-white);
 
       &:after {
         width: 1px;
-        background-color: grey;
+        background-color: var(--main-colours-esa-teal-55);
         content: "";
         position: absolute;
         transform: translateX(-50%);
-        width: 2px;
-        inset-block-start: var(--anchor-start);
-        inset-block-end: var(--anchor-end);
-        inset-inline: anchor(--dot-container center);
+        inset: var(--anchor-inset);
+        border-radius: 100px;
       }
     }
   }

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.module.css
@@ -1,5 +1,11 @@
 .chapterIndicator {
   --header-offset: calc(var(--header-height) / 2);
+  --dot-size: 6px;
+  --dot-color: var(--neutral-esa-white);
+
+  --dot-hover-size: calc(var(--dot-size) * 1.5);
+  --dot-active-size: calc(var(--dot-size) * 2);
+  --dot-focus-ring-color: color-mix(in srgb, var(--dot-color) 30%, transparent);
 
   z-index: 3;
   position: fixed;
@@ -9,26 +15,14 @@
   transform: translate(36px, -50%);
 
   .dotContainer {
-    --dot-size: 10px;
-    --dot-color: var(--neutral-esa-white);
     list-style-type: none;
     height: 100%;
-    display: grid;
-    align-content: space-between;
     justify-content: center;
     anchor-name: --dot-container;
+    place-items: start center;
 
-    .activeIndicator {
-      --indicator-size: calc(anchor-size(width, 100%) * 2);
-      --indicator-ring-offset: calc(var(--dot-size) * 0.8);
-      width: var(--indicator-size);
-      height: var(--indicator-size);
-      display: inline-block;
-      background-color: var(--dot-color);
-      box-sizing: border-box;
-      position: absolute;
-      position-area: center center;
-      border-radius: 50%;
+    @media screen and (--desktop-viewport) {
+      --dot-size: 6px;
     }
 
     > li.dot {
@@ -38,7 +32,9 @@
       height: var(--dot-size);
       border-radius: 50%;
       display: inline-block;
-      background-color: var(--dot-color);
+      position: absolute;
+      left: 50%;
+      transform: translate(-50%, -50%);
 
       .dotButton {
         all: unset;
@@ -46,23 +42,115 @@
         width: 100%;
         height: 100%;
         border-radius: inherit;
+        position: relative;
         cursor: pointer;
+        overflow: visible;
+
+        /* increase click area */
+        &:after {
+          content: "";
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          width: min(250%, 1rem);
+          height: min(250%, 1rem);
+        }
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          width: 100%;
+          height: 100%;
+          border-radius: 50%;
+          background-color: var(--dot-color);
+          transform: translate(-50%, -50%) scale(1);
+          transition:
+            transform 160ms ease,
+            box-shadow 160ms ease,
+            opacity 160ms ease;
+        }
+
+        &:hover {
+          &:before {
+            transform: translate(-50%, -50%)
+              scale(calc(var(--dot-hover-size) / var(--dot-size)));
+          }
+        }
+
+        &[data-active="true"]:hover {
+          &:before {
+            transform: translate(-50%, -50%)
+              scale(calc(var(--dot-active-size) / var(--dot-size)));
+          }
+        }
+
+        &:active {
+          &:before {
+            transform: translate(-50%, -50%)
+              scale(calc(var(--dot-active-size) / var(--dot-size)));
+          }
+        }
 
         &:focus-visible {
-          outline: 2px solid var(--neutral-esa-white);
-          outline-offset: 3px;
+          &:before {
+            transform: translate(-50%, -50%)
+              scale(calc(var(--dot-active-size) / var(--dot-size)));
+            box-shadow: 0 0 0 4px var(--dot-focus-ring-color);
+          }
         }
       }
+    }
 
-      &:after {
-        width: 1px;
-        background-color: var(--main-colours-esa-teal-55);
-        content: "";
-        position: absolute;
-        transform: translateX(-50%);
-        inset: var(--anchor-inset);
-        border-radius: 100px;
-      }
+    .line {
+      width: 1px;
+      background-color: var(--main-colours-esa-teal-55);
+      content: "";
+      position: absolute;
+      transform: translate(-50%, 0);
+      top: calc(var(--line-start) + 9px);
+      bottom: calc(100% - var(--line-end) + 9px);
+      left: 50%;
+    }
+  }
+  .activeIndicator {
+    --indicator-size: calc(var(--dot-size) * 1);
+    --indicator-ring-offset: 55%;
+    --indicator-ring-size: calc(var(--dot-size) * 2.2);
+    --indicator-ring-scale: 1;
+    transform-origin: center;
+
+    position: absolute;
+    will-change: top;
+    width: var(--indicator-size);
+    height: var(--indicator-size);
+    transform: translate(-50%, -50%);
+    display: inline-block;
+    background-color: var(--dot-color);
+    box-sizing: border-box;
+    position: absolute;
+    left: 50%;
+    border-radius: 50%;
+
+    &:after {
+      content: "";
+      width: var(--indicator-ring-size);
+      height: var(--indicator-ring-size);
+      scale: var(--indicator-ring-scale);
+      transform-origin: top left;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background-color: var(--dot-color);
+      border-radius: 50%;
+      mask: radial-gradient(
+        circle,
+        transparent 0 var(--indicator-ring-offset),
+        black var(--indicator-ring-offset) 100%
+      );
     }
   }
 }

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
@@ -1,4 +1,5 @@
-import { CSSProperties } from "react";
+import { CSSProperties, useState } from "react";
+import { motion } from "motion/react";
 import styles from "./chapter-indicator.module.css";
 
 interface Props {
@@ -6,22 +7,34 @@ interface Props {
 }
 
 const ChapterIndicator = ({ length }: Props) => {
+  const [activeIndicator, setActiveIndicator] = useState<number>(0);
+  console.log(
+    "🚀 ~ chapter-indicator.tsx:11 → activeIndicator:",
+    activeIndicator,
+  );
   return (
     <nav className={styles.chapterIndicator}>
       <ol className={styles.dotContainer}>
         {Array.from({ length }, (_, index) => (
           <li
+            onClick={() => setActiveIndicator(index)}
             style={
               {
                 anchorName: `--dot-${index}`,
-                "--anchor-start": `anchor(--dot-${index} end)`,
-                "--anchor-end": `anchor(--dot-${index + 1} start)`,
+                "--anchor-inset": `calc(anchor(--dot-${index} end) + var(--line-offset)) anchor(--dot-container center) calc(anchor(--dot-${index + 1} start) + var(--line-offset))`,
               } as CSSProperties
             }
             className={styles.dot}
             key={index}
           ></li>
         ))}
+        <motion.span
+          layout
+          className={styles.activeIndicator}
+          style={{
+            positionAnchor: `--dot-${activeIndicator}`,
+          }}
+        ></motion.span>
       </ol>
     </nav>
   );

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
@@ -1,0 +1,30 @@
+import { CSSProperties } from "react";
+import styles from "./chapter-indicator.module.css";
+
+interface Props {
+  length: number;
+}
+
+const ChapterIndicator = ({ length }: Props) => {
+  return (
+    <nav className={styles.chapterIndicator}>
+      <ol className={styles.dotContainer}>
+        {Array.from({ length }, (_, index) => (
+          <li
+            style={
+              {
+                anchorName: `--dot-${index}`,
+                "--anchor-start": `anchor(--dot-${index} end)`,
+                "--anchor-end": `anchor(--dot-${index + 1} start)`,
+              } as CSSProperties
+            }
+            className={styles.dot}
+            key={index}
+          ></li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default ChapterIndicator;

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
@@ -1,5 +1,5 @@
-import { CSSProperties, useState } from "react";
-import { motion } from "motion/react";
+import { CSSProperties, useRef, useState } from "react";
+import { motion, useAnimate } from "motion/react";
 import styles from "./chapter-indicator.module.css";
 
 interface Props {
@@ -8,16 +8,60 @@ interface Props {
 
 const ChapterIndicator = ({ length }: Props) => {
   const [activeIndicator, setActiveIndicator] = useState<number>(0);
-  console.log(
-    "🚀 ~ chapter-indicator.tsx:11 → activeIndicator:",
-    activeIndicator,
-  );
+  const resolveLayoutAnimation = useRef<(() => void) | null>(null);
+  const [scope, animate] = useAnimate();
+
+  const variants = {
+    initial: {
+      width: "var(--dot-size)",
+      height: "var(--dot-size)",
+      mask: "radial-gradient(circle, transparent 0 0px, black 0px)",
+    },
+    animate: {
+      width: "var(--indicator-size)",
+      height: "var(--indicator-size)",
+      mask: "radial-gradient(circle, transparent 0 var(--indicator-ring-offset), black var(--indicator-ring-offset))",
+    },
+  };
+
+  const waitForLayoutAnimation = () => {
+    // Finish any previous pending wait.
+    resolveLayoutAnimation.current?.();
+
+    return new Promise<void>((resolve) => {
+      resolveLayoutAnimation.current = resolve;
+    });
+  };
+
+  const completeLayoutAnimation = () => {
+    const resolve = resolveLayoutAnimation.current;
+    resolveLayoutAnimation.current = null;
+    resolve?.();
+  };
+
+  const moveIndicatorTo = async (index: number) => {
+    if (!scope.current) {
+      return;
+    }
+
+    // create promise which pauses execution until resolved by onLayoutAnimationComplete callback
+    const layoutFinished = waitForLayoutAnimation();
+
+    // shrink indicator to dot size
+    await animate(scope.current, variants.initial);
+
+    // set active index triggering layout change
+    setActiveIndicator(index);
+    await layoutFinished;
+
+    await animate(scope.current, variants.animate);
+  };
+
   return (
-    <nav className={styles.chapterIndicator}>
+    <motion.nav layoutRoot className={styles.chapterIndicator}>
       <ol className={styles.dotContainer}>
         {Array.from({ length }, (_, index) => (
           <li
-            onClick={() => setActiveIndicator(index)}
             style={
               {
                 anchorName: `--dot-${index}`,
@@ -26,17 +70,33 @@ const ChapterIndicator = ({ length }: Props) => {
             }
             className={styles.dot}
             key={index}
-          ></li>
+          >
+            <button
+              type="button"
+              className={styles.dotButton}
+              aria-label={`Go to chapter ${index + 1}`}
+              aria-current={index === activeIndicator ? "step" : undefined}
+              onClick={() => moveIndicatorTo(index)}
+            />
+          </li>
         ))}
+
         <motion.span
+          ref={scope}
+          variants={variants}
+          initial="animate"
           layout
+          transition={{
+            layout: { duration: 0.4, ease: [0.4, 0, 0.2, 1] },
+          }}
+          onLayoutAnimationComplete={completeLayoutAnimation}
           className={styles.activeIndicator}
           style={{
             positionAnchor: `--dot-${activeIndicator}`,
           }}
         ></motion.span>
       </ol>
-    </nav>
+    </motion.nav>
   );
 };
 

--- a/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
+++ b/src/scripts/components/main/chapter-indicator/chapter-indicator.tsx
@@ -1,102 +1,116 @@
-import { CSSProperties, useRef, useState } from "react";
-import { motion, useAnimate } from "motion/react";
+import { CSSProperties, Fragment } from "react";
+import { motion, useTransform } from "motion/react";
+
+import { useStoryScroll } from "../../../hooks/use-story-scroll";
+import { useModuleScroll } from "../../../hooks/use-module-scroll";
+import { useStory } from "../../../providers/story/use-story";
+
 import styles from "./chapter-indicator.module.css";
 
-interface Props {
-  length: number;
-}
+const ChapterIndicator = () => {
+  const { story, getModuleRefsMap } = useStory();
 
-const ChapterIndicator = ({ length }: Props) => {
-  const [activeIndicator, setActiveIndicator] = useState<number>(0);
-  const resolveLayoutAnimation = useRef<(() => void) | null>(null);
-  const [scope, animate] = useAnimate();
+  const { heightFractionPerModule } = useModuleScroll();
 
-  const variants = {
-    initial: {
-      width: "var(--dot-size)",
-      height: "var(--dot-size)",
-      mask: "radial-gradient(circle, transparent 0 0px, black 0px)",
+  function scrollToNode(index: number) {
+    const nodes = getModuleRefsMap();
+    nodes.get(`${index}`)?.scrollIntoView({ behavior: "smooth" });
+  }
+
+  const { scrollYProgress } = useStoryScroll({});
+
+  const top = useTransform(scrollYProgress, [0, 1], ["0%", "100%"]);
+
+  const transitionArea = 0.025;
+  const fractionLength = heightFractionPerModule?.length ?? Infinity;
+
+  // this makes the outer ring of the activeIndicator transform depending the current scroll
+  // we dynamically generate input and output array to pass to useTransform
+  const transformableHeightFractions = heightFractionPerModule?.reduce(
+    (prev, fraction, index) => {
+      //  handle first fraction
+      if (index === 0) {
+        return [
+          [0, fraction + transitionArea],
+          [1, 0],
+        ];
+      }
+
+      // handle last fraction
+      if (index === fractionLength - 1) {
+        return [
+          [...prev[0], fraction - transitionArea, fraction],
+          [...prev[1], 0, 1],
+        ];
+      }
+
+      return [
+        [
+          ...prev[0],
+          fraction - transitionArea,
+          fraction,
+          fraction + transitionArea,
+        ],
+        [...prev[1], 0, 1, 0],
+      ];
     },
-    animate: {
-      width: "var(--indicator-size)",
-      height: "var(--indicator-size)",
-      mask: "radial-gradient(circle, transparent 0 var(--indicator-ring-offset), black var(--indicator-ring-offset))",
-    },
-  };
+    [] as Array<Array<number> | Array<number>>,
+  ) ?? [[1], [1]];
 
-  const waitForLayoutAnimation = () => {
-    // Finish any previous pending wait.
-    resolveLayoutAnimation.current?.();
-
-    return new Promise<void>((resolve) => {
-      resolveLayoutAnimation.current = resolve;
-    });
-  };
-
-  const completeLayoutAnimation = () => {
-    const resolve = resolveLayoutAnimation.current;
-    resolveLayoutAnimation.current = null;
-    resolve?.();
-  };
-
-  const moveIndicatorTo = async (index: number) => {
-    if (!scope.current) {
-      return;
-    }
-
-    // create promise which pauses execution until resolved by onLayoutAnimationComplete callback
-    const layoutFinished = waitForLayoutAnimation();
-
-    // shrink indicator to dot size
-    await animate(scope.current, variants.initial);
-
-    // set active index triggering layout change
-    setActiveIndicator(index);
-    await layoutFinished;
-
-    await animate(scope.current, variants.animate);
-  };
+  const ringScale = useTransform(
+    scrollYProgress,
+    transformableHeightFractions[0],
+    transformableHeightFractions[1],
+  );
 
   return (
-    <motion.nav layoutRoot className={styles.chapterIndicator}>
+    <nav key={story?.id} className={styles.chapterIndicator}>
       <ol className={styles.dotContainer}>
-        {Array.from({ length }, (_, index) => (
-          <li
-            style={
-              {
-                anchorName: `--dot-${index}`,
-                "--anchor-inset": `calc(anchor(--dot-${index} end) + var(--line-offset)) anchor(--dot-container center) calc(anchor(--dot-${index + 1} start) + var(--line-offset))`,
-              } as CSSProperties
-            }
-            className={styles.dot}
-            key={index}
-          >
-            <button
-              type="button"
-              className={styles.dotButton}
-              aria-label={`Go to chapter ${index + 1}`}
-              aria-current={index === activeIndicator ? "step" : undefined}
-              onClick={() => moveIndicatorTo(index)}
-            />
-          </li>
-        ))}
+        {[...(heightFractionPerModule ?? [])]?.map((height, index) => {
+          const lineEnd = (heightFractionPerModule?.[index + 1] ?? 0) * 100;
 
-        <motion.span
-          ref={scope}
-          variants={variants}
-          initial="animate"
-          layout
-          transition={{
-            layout: { duration: 0.4, ease: [0.4, 0, 0.2, 1] },
-          }}
-          onLayoutAnimationComplete={completeLayoutAnimation}
-          className={styles.activeIndicator}
-          style={{
-            positionAnchor: `--dot-${activeIndicator}`,
-          }}
-        ></motion.span>
+          return (
+            <Fragment key={index}>
+              <li
+                style={
+                  {
+                    top: `${height * 100}%`,
+                  } as CSSProperties
+                }
+                className={styles.dot}
+              >
+                <button
+                  type="button"
+                  className={styles.dotButton}
+                  aria-label={`Go to chapter ${index + 1}`}
+                  onClick={() => scrollToNode(index)}
+                />
+              </li>
+              <span
+                aria-hidden="true"
+                className={styles.line}
+                style={
+                  {
+                    "--line-start": `${height * 100}%`,
+                    "--line-end": `${lineEnd}%`,
+                  } as CSSProperties
+                }
+              ></span>
+            </Fragment>
+          );
+        })}
       </ol>
-    </motion.nav>
+
+      <motion.span
+        className={styles.activeIndicator}
+        style={
+          {
+            top,
+            "--indicator-ring-scale": ringScale,
+          } as unknown as CSSProperties
+        }
+      ></motion.span>
+    </nav>
   );
 };
 

--- a/src/scripts/components/stories/story/blocks/closing-screen/closing-screen.tsx
+++ b/src/scripts/components/stories/story/blocks/closing-screen/closing-screen.tsx
@@ -5,7 +5,9 @@ import { TextWrapper } from "../generic/text-container/text-wrapper";
 import { StorySectionProps } from "../../../../../types/story";
 import { useContentParams } from "../../../../../hooks/use-content-params";
 
-export const ClosingScreen: FunctionComponent<StorySectionProps> = () => {
+export const ClosingScreen: FunctionComponent<StorySectionProps> = ({
+  ref,
+}) => {
   const { story } = useStory();
 
   const { category } = useContentParams();
@@ -18,7 +20,7 @@ export const ClosingScreen: FunctionComponent<StorySectionProps> = () => {
   const message = formatMessage({ id: "exploreMoreInCategory" }, { category });
 
   return (
-    <div style={{ backgroundColor: "#011e2b" }}>
+    <div style={{ backgroundColor: "#011e2b" }} ref={ref}>
       <TextWrapper text={message} />
     </div>
   );

--- a/src/scripts/components/stories/story/blocks/globe/story-globe/story-globe.module.css
+++ b/src/scripts/components/stories/story/blocks/globe/story-globe/story-globe.module.css
@@ -58,7 +58,6 @@
   .globeContainer {
     position: relative;
     display: flex;
-    height: 100%;
     justify-content: center;
     background: var(--neutral-esa-background);
 

--- a/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
+++ b/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
@@ -25,9 +25,7 @@ import cx from "classnames";
 
 import styles from "./splashscreen.module.css";
 
-export const SplashScreen: FunctionComponent<StorySectionProps> = ({
-  ...rest
-}) => {
+export const SplashScreen: FunctionComponent<StorySectionProps> = (rest) => {
   const { isStoryEEI } = useAppRouteFlags();
   const { story, setScrollAnchorRefs } = useStory();
   const targetRef = useRef<HTMLDivElement>(null);

--- a/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
+++ b/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
@@ -25,7 +25,9 @@ import cx from "classnames";
 
 import styles from "./splashscreen.module.css";
 
-export const SplashScreen: FunctionComponent<StorySectionProps> = () => {
+export const SplashScreen: FunctionComponent<StorySectionProps> = ({
+  ...rest
+}) => {
   const { isStoryEEI } = useAppRouteFlags();
   const { story, setScrollAnchorRefs } = useStory();
   const targetRef = useRef<HTMLDivElement>(null);
@@ -90,6 +92,7 @@ export const SplashScreen: FunctionComponent<StorySectionProps> = () => {
   return (
     <SlideContainer
       className={cx(styles.splashscreenContainer, styles.locationStory)}
+      {...rest}
     >
       <div
         style={{

--- a/src/scripts/components/stories/story/story.tsx
+++ b/src/scripts/components/stories/story/story.tsx
@@ -48,7 +48,7 @@ const Story: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
         id="story"
       >
         <ChapterIndicator />
-        <SplashScreen ref={setModuleRefs(`${0}`)} />
+        <SplashScreen ref={setModuleRefs('0')} />
 
         {story.modules.map(({ type }, moduleIndex) => {
           const ModuleComponent = getModuleComponent(type);

--- a/src/scripts/components/stories/story/story.tsx
+++ b/src/scripts/components/stories/story/story.tsx
@@ -46,7 +46,7 @@ const Story: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
         ref={storyElementRef}
         id="story"
       >
-        <ChapterIndicator length={story.modules.length} />
+        <ChapterIndicator length={story.modules.length + 1} />
         <SplashScreen />
 
         {story.modules.map(({ type }, moduleIndex) => {

--- a/src/scripts/components/stories/story/story.tsx
+++ b/src/scripts/components/stories/story/story.tsx
@@ -23,7 +23,8 @@ import styles from "./story.module.css";
  * The hierarchical structure of a story is organized as follows: story > module > slides
  */
 const Story: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
-  const { storyElementRef, story, setScrollAnchorRefs } = useStory();
+  const { storyElementRef, story, setScrollAnchorRefs, setModuleRefs } =
+    useStory();
 
   // Initialize Lenis for smooth scrolling behavior in the story
   useLenisForStory();
@@ -46,8 +47,8 @@ const Story: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
         ref={storyElementRef}
         id="story"
       >
-        <ChapterIndicator length={story.modules.length + 1} />
-        <SplashScreen />
+        <ChapterIndicator />
+        <SplashScreen ref={setModuleRefs(`${0}`)} />
 
         {story.modules.map(({ type }, moduleIndex) => {
           const ModuleComponent = getModuleComponent(type);
@@ -67,12 +68,14 @@ const Story: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
               storyId={story.id}
               getRefCallback={generateScrollAnchorRef}
             >
-              <ModuleComponent />
+              <section ref={setModuleRefs(`${moduleIndex + 1}`)}>
+                <ModuleComponent />
+              </section>
             </ModuleContentProvider>
           );
         })}
         {/* Provisional - will be replaced with a proper end screen later */}
-        <ClosingScreen />
+        <ClosingScreen ref={setModuleRefs(`${story.modules.length + 1}`)} />
       </main>
       {children}
     </>

--- a/src/scripts/components/stories/story/story.tsx
+++ b/src/scripts/components/stories/story/story.tsx
@@ -9,6 +9,7 @@ import { useSyncStoryUrl } from "../../../hooks/use-sync-story-url";
 import { ModuleContentProvider } from "../../../providers/story/module-content/module-content-provider";
 import { ClosingScreen } from "./blocks/closing-screen/closing-screen";
 import { SplashScreen } from "./blocks/splashscreen/splashscreen";
+import ChapterIndicator from "../../main/chapter-indicator/chapter-indicator";
 
 import { getModuleComponent } from "../../../libs/get-story-components";
 
@@ -45,6 +46,7 @@ const Story: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
         ref={storyElementRef}
         id="story"
       >
+        <ChapterIndicator length={story.modules.length} />
         <SplashScreen />
 
         {story.modules.map(({ type }, moduleIndex) => {

--- a/src/scripts/hooks/use-module-scroll.ts
+++ b/src/scripts/hooks/use-module-scroll.ts
@@ -20,6 +20,8 @@ export function useModuleScroll() {
     const maxScrollY =
       Array.from(nodes.values()).at(-1)?.getBoundingClientRect().y || 0;
 
+    // The chapter indicator needs each module's relative position up front so its
+    // dots and active ring stay aligned with the actual scroll path of the story.
     const scrollYPerModule = Array.from(nodes.values()).map((node) => {
       const heigth = quantize(
         (node.getBoundingClientRect().y - minScroll) /

--- a/src/scripts/hooks/use-module-scroll.ts
+++ b/src/scripts/hooks/use-module-scroll.ts
@@ -1,7 +1,6 @@
 import { useStory } from "../providers/story/use-story";
 import { useEffect, useEffectEvent, useState } from "react";
 import { quantize } from "../libs/quantize";
-import { getCssVarPx } from "../libs/get-css-var-in-px";
 
 export function useModuleScroll() {
   const { getModuleRefsMap, story } = useStory();
@@ -10,8 +9,6 @@ export function useModuleScroll() {
 
   const onMount = useEffectEvent(() => {
     const nodes = getModuleRefsMap();
-
-    const headerHeight = getCssVarPx("--header-height");
 
     const minScroll =
       Array.from(nodes.values()).at(0)?.getBoundingClientRect().y || 0;
@@ -24,8 +21,7 @@ export function useModuleScroll() {
     // dots and active ring stay aligned with the actual scroll path of the story.
     const scrollYPerModule = Array.from(nodes.values()).map((node) => {
       const heigth = quantize(
-        (node.getBoundingClientRect().y - minScroll) /
-          (maxScrollY - headerHeight - minScroll),
+        (node.getBoundingClientRect().y - minScroll) / (maxScrollY - minScroll),
         0.0001,
       );
 

--- a/src/scripts/hooks/use-module-scroll.ts
+++ b/src/scripts/hooks/use-module-scroll.ts
@@ -1,0 +1,45 @@
+import { useStory } from "../providers/story/use-story";
+import { useEffect, useEffectEvent, useState } from "react";
+import { quantize } from "../libs/quantize";
+import { getCssVarPx } from "../libs/get-css-var-in-px";
+
+export function useModuleScroll() {
+  const { getModuleRefsMap, story } = useStory();
+  const [heightFractionPerModule, setHeightFractionPerModule] =
+    useState<Array<number>>();
+
+  const onMount = useEffectEvent(() => {
+    const nodes = getModuleRefsMap();
+
+    const headerHeight = getCssVarPx("--header-height");
+
+    const minScroll =
+      Array.from(nodes.values()).at(0)?.getBoundingClientRect().y || 0;
+
+    // get scroll height
+    const maxScrollY =
+      Array.from(nodes.values()).at(-1)?.getBoundingClientRect().y || 0;
+
+    const scrollYPerModule = Array.from(nodes.values()).map((node) => {
+      const heigth = quantize(
+        (node.getBoundingClientRect().y - minScroll) /
+          (maxScrollY - headerHeight - minScroll),
+        0.0001,
+      );
+
+      return heigth;
+    });
+
+    setHeightFractionPerModule(scrollYPerModule);
+  });
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    onMount();
+  }, [story]);
+
+  return {
+    moduleLength: heightFractionPerModule?.length,
+    heightFractionPerModule,
+  };
+}

--- a/src/scripts/providers/story/story-provider.tsx
+++ b/src/scripts/providers/story/story-provider.tsx
@@ -9,6 +9,10 @@ export interface StoryContextValue {
   story: Story | null;
   storyElementRef: RefObject<HTMLDivElement | null>;
   lenisRef: RefObject<Lenis | null>;
+  getModuleRefsMap: () => Map<string, Element>;
+  setModuleRefs: (
+    key: string,
+  ) => (node: HTMLElement | null | undefined) => void;
   getScrollAnchorRefsMap: () => Map<string, Element>;
   setScrollAnchorRefs: (
     key: string,
@@ -34,20 +38,22 @@ export function StoryProvider({ children, story }: StoryProviderProps) {
   // Add a node to this Map for the intersection observer to detect it and adjust the URL parameters accordingly.
   const scrollAnchorRefs = useRef<Map<string, Element>>(null);
 
-  const getMap = useCallback(() => {
-    return (scrollAnchorRefs.current ??= new Map<AnchorKey, HTMLElement>());
+  const moduleRefs = useRef<Map<string, Element>>(null);
+
+  const getModuleRefs = useCallback(() => {
+    return (moduleRefs.current ??= new Map<string, HTMLElement>());
   }, []);
 
-  const getScrollAnchorRefsMap = useCallback(() => {
-    const map = getMap();
+  const getModuleRefsMap = useCallback(() => {
+    const map = getModuleRefs();
     return new Map(
       [...map.entries()].sort(([a], [b]) => collator.compare(a, b)),
     );
-  }, [getMap]);
+  }, [getModuleRefs]);
 
-  const setScrollAnchorRefs = useCallback(
+  const setModuleRefs = useCallback(
     (key: string) => (node: HTMLElement | undefined | null) => {
-      const map = getMap();
+      const map = getModuleRefs();
 
       if (node) {
         map.set(key, node);
@@ -55,7 +61,31 @@ export function StoryProvider({ children, story }: StoryProviderProps) {
         map.delete(key);
       }
     },
-    [getMap],
+    [getModuleRefs],
+  );
+
+  const getScrollAnchorRefs = useCallback(() => {
+    return (scrollAnchorRefs.current ??= new Map<AnchorKey, HTMLElement>());
+  }, []);
+
+  const getScrollAnchorRefsMap = useCallback(() => {
+    const map = getScrollAnchorRefs();
+    return new Map(
+      [...map.entries()].sort(([a], [b]) => collator.compare(a, b)),
+    );
+  }, [getScrollAnchorRefs]);
+
+  const setScrollAnchorRefs = useCallback(
+    (key: string) => (node: HTMLElement | undefined | null) => {
+      const map = getScrollAnchorRefs();
+
+      if (node) {
+        map.set(key, node);
+      } else {
+        map.delete(key);
+      }
+    },
+    [getScrollAnchorRefs],
   );
 
   return (
@@ -65,6 +95,8 @@ export function StoryProvider({ children, story }: StoryProviderProps) {
         storyElementRef,
         getScrollAnchorRefsMap,
         setScrollAnchorRefs,
+        getModuleRefsMap,
+        setModuleRefs,
         lenisRef,
       }}
     >

--- a/storage/stories/debug/debug-en.json
+++ b/storage/stories/debug/debug-en.json
@@ -8,7 +8,7 @@
     "altText": "An example of all the components",
     "slides": [
       {
-        "text": "There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc."
+        "text": "There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable."
       }
     ]
   },


### PR DESCRIPTION
closes #2228 

- it differs slightly from the original intent where each slide was represented by a dot. Instead, we have a dot per module and the section's length of the "indicator line" represent each module's length. We do this, because for longer stories (especially on mobile), the dots would be really tightly placed to each other

<img width="963" height="875" alt="Screenshot 2026-07-30 at 17 10 04" src="https://github.com/user-attachments/assets/9cf619bd-8fb2-4707-8158-28545b658d9d" />