### PR TITLE
fix(chapter-indicator): fix chapter indicator in scroll stories

### DIFF
--- a/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
+++ b/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
@@ -1,6 +1,6 @@
-import { FunctionComponent, useEffect, useRef } from "react";
+import { FunctionComponent, RefObject, useEffect  } from "react";
 import { useDispatch } from "react-redux";
-import { motion, useTransform } from "motion/react";
+import { motion,  useTransform } from "motion/react";
 
 import { setFlyTo } from "../../../../../reducers/fly-to";
 
@@ -29,12 +29,13 @@ import styles from "./splashscreen.module.css";
 export const SplashScreen: FunctionComponent<StorySectionProps> = (rest) => {
   const { isStoryEEI, isStoryXFires } = useAppRouteFlags();
   const { story, setScrollAnchorRefs } = useStory();
-  const targetRef = useRef<HTMLDivElement>(null);
+
+  const { ref } = rest;
 
   const dispatch = useDispatch();
 
   const { scrollYProgress } = useStoryScroll({
-    target: targetRef,
+    target: ref as RefObject<HTMLElement>,
     offset: ["start start", "end start"],
   });
 
@@ -83,10 +84,10 @@ export const SplashScreen: FunctionComponent<StorySectionProps> = (rest) => {
 
   // Render SplashScreen for scroll stories
   if (isStoryEEI) {
-    return <SplashScreenEei />;
+    return <SplashScreenEei ref={ref} />;
   }
   if (isStoryXFires) {
-    return <SplashScreenXFires />;
+    return <SplashScreenXFires ref={ref} />;
   }
 
   const { id } = story;
@@ -101,7 +102,7 @@ export const SplashScreen: FunctionComponent<StorySectionProps> = (rest) => {
           // plus one to account for the intro slide
           height: `calc(${totalSlides + 1} * var(--story-height))`,
         }}
-        ref={targetRef}
+        ref={ref}
         className={styles.splashBanner}
       >
         {/* needs to be placed outside of the content container, will other interfere with the transition calculation of framer */}

--- a/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
+++ b/src/scripts/components/stories/story/blocks/splashscreen/splashscreen.tsx
@@ -1,6 +1,6 @@
-import { FunctionComponent, RefObject, useEffect  } from "react";
+import { FunctionComponent, RefObject, useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { motion,  useTransform } from "motion/react";
+import { motion, useTransform } from "motion/react";
 
 import { setFlyTo } from "../../../../../reducers/fly-to";
 

--- a/src/scripts/components/stories/story/scroll-story/modules/base-scroll/module/scroll-module.tsx
+++ b/src/scripts/components/stories/story/scroll-story/modules/base-scroll/module/scroll-module.tsx
@@ -2,6 +2,7 @@ import {
   CSSProperties,
   FunctionComponent,
   PropsWithChildren,
+  RefObject,
   useMemo,
   useRef,
 } from "react";
@@ -15,15 +16,10 @@ import cx from "classnames";
 
 import styles from "./scroll-module.module.css";
 
-type Props<TConfig = unknown> = PropsWithChildren<
-  Omit<
-    StorySectionProps & {
-      config: TConfig;
-      lengthFactor: number;
-    },
-    "ref"
-  >
->;
+type Props<TConfig = unknown> = StorySectionProps & {
+  config: TConfig;
+  lengthFactor: number;
+};
 
 const StickyContainer = ({
   children,
@@ -41,16 +37,24 @@ const StickyContainer = ({
   );
 };
 
+/**
+ * We use this as a wrapper to for scroll module. It provides us with the current absolute and relative scroll position within the story
+ * This component may receive a refTarget from a parent component e.g. to add it to mooduleRefsMap which is used to track progress of story in the chapter-progress-indicator
+ * If no ref is passed, we create a local ref in order to still have a reference to the element
+ */
 const ScrollModule: FunctionComponent<Props> & {
   StickyContainer: typeof StickyContainer;
-} = ({ children, className, config, lengthFactor, ...rest }) => {
+} = ({ children, className, config, lengthFactor, refTarget, ...rest }) => {
   if (lengthFactor === null || typeof lengthFactor !== "number") {
     console.warn(
       "Warning: lengthFactor is missing or not a number in ScrollModule. This can cause out-of-sync globe movements",
       lengthFactor,
     );
   }
-  const moduleRef = useRef(null);
+
+  const localRef = useRef(null);
+  // local ref only used if no ref prop is passed
+  const moduleRef = (refTarget ?? localRef) as RefObject<HTMLDivElement>;
 
   const { scrollY, scrollYProgress } = useStoryScroll({
     target: moduleRef,

--- a/src/scripts/components/stories/story/scroll-story/modules/base-scroll/module/scroll-module.tsx
+++ b/src/scripts/components/stories/story/scroll-story/modules/base-scroll/module/scroll-module.tsx
@@ -38,8 +38,8 @@ const StickyContainer = ({
 };
 
 /**
- * We use this as a wrapper to for scroll module. It provides us with the current absolute and relative scroll position within the story
- * This component may receive a refTarget from a parent component e.g. to add it to mooduleRefsMap which is used to track progress of story in the chapter-progress-indicator
+ * We use this as a wrapper for the scroll module. It provides us with the current absolute and relative scroll position within the story
+ * This component may receive a refTarget from a parent component e.g. to add it to moduleRefsMap which is used to track progress of story in the chapter-progress-indicator
  * If no ref is passed, we create a local ref in order to still have a reference to the element
  */
 const ScrollModule: FunctionComponent<Props> & {

--- a/src/scripts/components/stories/story/scroll-story/story-eei/splashscreen/splashscreen-eei.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-eei/splashscreen/splashscreen-eei.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from "react";
+import { FunctionComponent, Ref } from "react";
 import { motion, useTransform } from "motion/react";
 
 import { useScrollModule } from "../../modules/base-scroll/use-scroll-module";
@@ -32,12 +32,17 @@ const Title: FunctionComponent<{ title: string }> = ({ title }) => {
   );
 };
 
-export default function SplashscreenEei() {
+interface Props {
+  ref: Ref<HTMLElement> | undefined;
+}
+
+export default function SplashscreenEei({ ref }: Props) {
   const { story, setScrollAnchorRefs } = useStory();
   const splashConfig = story?.splashscreen;
 
   return (
     <ScrollModule
+      refTarget={ref}
       config={animationConfig}
       lengthFactor={splashConfig?.lengthFactor ?? 1}
     >

--- a/src/scripts/components/stories/story/scroll-story/story-x-fires/splashscreen/splashscreen-x-fires.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-x-fires/splashscreen/splashscreen-x-fires.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from "react";
+import { FunctionComponent, Ref } from "react";
 import { motion, useTransform } from "motion/react";
 
 import { useScrollModule } from "../../modules/base-scroll/use-scroll-module";
@@ -13,6 +13,10 @@ const animationConfig = {
   input: [0.5, 1],
   output: ["-10vh", "-50vh"],
 };
+
+interface Props {
+  ref: Ref<HTMLElement> | undefined;
+}
 
 const Title: FunctionComponent<{ title: string }> = ({ title }) => {
   const { scrollYProgress } = useScrollModule<typeof animationConfig>();
@@ -32,12 +36,13 @@ const Title: FunctionComponent<{ title: string }> = ({ title }) => {
   );
 };
 
-export default function SplashScreenXFires() {
+export default function SplashScreenXFires({ ref }: Props) {
   const { story, setScrollAnchorRefs } = useStory();
   const splashConfig = story?.splashscreen;
 
   return (
     <ScrollModule
+      refTarget={ref}
       config={animationConfig}
       lengthFactor={splashConfig?.lengthFactor ?? 1}
     >

--- a/src/scripts/types/story.ts
+++ b/src/scripts/types/story.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, FunctionComponent, Ref, RefObject } from "react";
+import { ComponentProps, FunctionComponent, Ref } from "react";
 
 import { EmbeddedItem, GlobeItem, ImageItem, VideoItem } from "./gallery-item";
 import { ImageGallery } from "../components/stories/story/blocks/image-gallery/image-gallery";

--- a/src/scripts/types/story.ts
+++ b/src/scripts/types/story.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, FunctionComponent } from "react";
+import { ComponentProps, FunctionComponent, Ref, RefObject } from "react";
 
 import { EmbeddedItem, GlobeItem, ImageItem, VideoItem } from "./gallery-item";
 import { ImageGallery } from "../components/stories/story/blocks/image-gallery/image-gallery";
@@ -179,7 +179,9 @@ export type GetRefCallback = (
   subIndex: number,
 ) => (node: HTMLElement | null) => void;
 
-export type StorySectionProps = {} & ComponentProps<"div">;
+export type StorySectionProps = ComponentProps<"div"> & {
+  refTarget?: Ref<HTMLElement>;
+};
 
 export const imageGalleryModuleMap: Record<
   ImageModule["type"],


### PR DESCRIPTION
for #2403 

- fixes the issue where for the scroll stories ("eei" and "xfires") the chapter indicator would not work correctly. This is because the ref to determine module elements was not handled correctly in the splashscreen