### PR TITLE
feat(x-fires): adpat image-sequence scroll to use landscape videos

### DIFF
--- a/scripts/extract-video-frames.js
+++ b/scripts/extract-video-frames.js
@@ -13,6 +13,7 @@ const DEFAULTS = {
   format: "webp",
   quality: 82,
   prefix: "frame",
+  landscape: false,
 };
 
 const MANIFEST_FILE_NAME = "image-sequence.json";
@@ -35,12 +36,13 @@ Optional:
   --format <type>      webp, jpg, jpeg, png (default: ${DEFAULTS.format})
   --quality <1-100>    Output quality for webp/jpg (default: ${DEFAULTS.quality})
   --prefix <name>      Output filename prefix (default: ${DEFAULTS.prefix})
+  --landscape          Generate the landscape sequence (default: portrait)
   --help               Show this help message
 
 Examples:
   node ./scripts/extract-video-frames.js --input ./video.mp4 --output ./frames
   node ./scripts/extract-video-frames.js --input ./video.mp4 --output ./frames --fps 24 --width 1080
-  node ./scripts/extract-video-frames.js --input ./video.mp4 --output ./frames --width 1080 --height 1080 --format png`);
+  node ./scripts/extract-video-frames.js --input ./video.mp4 --output ./frames --landscape --width 1080 --height 1080 --format png`);
 }
 
 function parseArgs(argv) {
@@ -53,6 +55,7 @@ function parseArgs(argv) {
     format: DEFAULTS.format,
     quality: DEFAULTS.quality,
     prefix: DEFAULTS.prefix,
+    landscape: DEFAULTS.landscape,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -60,6 +63,11 @@ function parseArgs(argv) {
 
     if (arg === "--help" || arg === "-h") {
       options.help = true;
+      continue;
+    }
+
+    if (arg === "--landscape") {
+      options.landscape = true;
       continue;
     }
 
@@ -137,7 +145,9 @@ function normalizeFormat(value) {
   const format = value.toLowerCase();
 
   if (!SUPPORTED_FORMATS.has(format)) {
-    throw new Error(`Unsupported format: ${value}. Use webp, jpg, jpeg, or png.`);
+    throw new Error(
+      `Unsupported format: ${value}. Use webp, jpg, jpeg, or png.`,
+    );
   }
 
   return format === "jpeg" ? "jpg" : format;
@@ -215,7 +225,8 @@ function getGeneratedFrameCount(outputDir, prefix, format) {
   return fs
     .readdirSync(outputDir)
     .filter(
-      (file) => file.startsWith(`${prefix}-`) && file.toLowerCase().endsWith(extension),
+      (file) =>
+        file.startsWith(`${prefix}-`) && file.toLowerCase().endsWith(extension),
     ).length;
 }
 
@@ -224,7 +235,8 @@ function getGeneratedFrameSize(outputDir, prefix, format) {
   const firstFrame = fs
     .readdirSync(outputDir)
     .find(
-      (file) => file.startsWith(`${prefix}-`) && file.toLowerCase().endsWith(extension),
+      (file) =>
+        file.startsWith(`${prefix}-`) && file.toLowerCase().endsWith(extension),
     );
 
   if (!firstFrame) {
@@ -272,7 +284,11 @@ function getGeneratedFrameSize(outputDir, prefix, format) {
 function writeImageSequenceManifest(outputDir, manifest) {
   const manifestPath = path.join(outputDir, MANIFEST_FILE_NAME);
 
-  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  fs.writeFileSync(
+    manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
 
   return manifestPath;
 }
@@ -370,7 +386,10 @@ async function main() {
     ensureFfmpeg();
 
     const inputPath = path.resolve(options.input);
-    const outputDir = path.resolve(options.output);
+    const outputDir = path.join(
+      path.resolve(options.output),
+      options.landscape ? "landscape" : "portrait",
+    );
 
     if (!fs.existsSync(inputPath) || !fs.statSync(inputPath).isFile()) {
       throw new Error(`Input file not found: ${options.input}`);

--- a/src/scripts/components/stories/story/scroll-story/modules/base-scroll/scroll-image-sequence/scroll-image-sequence.module.css
+++ b/src/scripts/components/stories/story/scroll-story/modules/base-scroll/scroll-image-sequence/scroll-image-sequence.module.css
@@ -1,5 +1,7 @@
 .sequenceContainer {
   height: 100%;
+  position: absolute;
+  inset: 0;
   opacity: var(--sequence-opacity);
   align-items: center;
   display: flex;

--- a/src/scripts/components/stories/story/scroll-story/modules/base-scroll/scroll-image-sequence/scroll-image-sequence.tsx
+++ b/src/scripts/components/stories/story/scroll-story/modules/base-scroll/scroll-image-sequence/scroll-image-sequence.tsx
@@ -45,6 +45,7 @@ interface ScrollImageSequenceConfig {
  * 1. Make sure `ffmpeg` is installed.
  * 2. Run `scripts/extract-video-frames.js` with an input video and output directory.
  *    The script generates the frame files and `image-sequence.json` manifest.
+ *    (by default, the script will generate image sequence in portrait. For landscape (desktop), add the --landscape flage)
  * 3. upload generated frames to the gcp story storage under assets/
  * 4. Add this to the story module content:
  *    ```json

--- a/src/scripts/components/stories/story/scroll-story/modules/base-scroll/scroll-image-sequence/scroll-image-sequence.tsx
+++ b/src/scripts/components/stories/story/scroll-story/modules/base-scroll/scroll-image-sequence/scroll-image-sequence.tsx
@@ -14,6 +14,7 @@ import mainConfig from "../../../../../../../config/main";
 import { replaceUrlPlaceholders } from "../../../../../../../libs/replace-url-placeholders";
 import {
   getImageSequenceFrameIndex,
+  getImageSequenceBasePath,
   getImageSequenceManifestSrc,
   getImageSequenceFrameSrc,
   ImageSequenceManifest,
@@ -79,8 +80,16 @@ export default function ScrollImageSequence({ className, sequence }: Props) {
     mainConfig.api.storyImageSequenceBase,
     { id: story?.id ?? "" },
   );
-  const frameBasePath = `${storyImageSequenceBase}/${sequence.path}`;
-  const manifestSrc = getImageSequenceManifestSrc(frameBasePath);
+  const sequenceBasePath = `${storyImageSequenceBase}/${sequence.path}`;
+  const sequenceVariant = isMobile ? "portrait" : "landscape";
+  const frameBasePath = getImageSequenceBasePath(
+    sequenceBasePath,
+    sequenceVariant,
+  );
+  const manifestSrc = getImageSequenceManifestSrc(
+    sequenceBasePath,
+    sequenceVariant,
+  );
 
   const drawImageCover = useCallback(
     (

--- a/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/australian-fires/australian-fires.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/australian-fires/australian-fires.tsx
@@ -10,7 +10,7 @@ const animationConfig = {
   imageSequence: {
     progressRange: [0, 1],
     input: [0, 0.95, 1],
-    output: [100, 100, 0],
+    output: [100, 100, 50],
   },
   scrollText1: {
     input: [0, 0.075, 0.225, 0.3],

--- a/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/canadian-fires/canadian-fires.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/canadian-fires/canadian-fires.tsx
@@ -11,7 +11,7 @@ const animationConfig = {
   imageSequence: {
     progressRange: [0, 1],
     input: [0, 0.95, 1],
-    output: [100, 100, 0],
+    output: [100, 100, 50],
   },
   scrollText1: {
     input: [0, 0.075, 0.225, 0.3],

--- a/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/hurricane-ophelia/hurricane-ophelia.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/hurricane-ophelia/hurricane-ophelia.tsx
@@ -12,8 +12,8 @@ const animationConfig = {
     output: [100, 100, 0],
   },
   scrollText1: {
-    input: [0, 0.225, 0.3],
-    output: ["0%", "0%", "-100%"],
+    input: [0, 0.2, 0.25],
+    output: ["0%", "0%", "100%"],
   },
   scrollText2: {
     input: [0.3, 0.375, 0.525, 0.55],

--- a/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/hurricane-ophelia/hurricane-ophelia.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/hurricane-ophelia/hurricane-ophelia.tsx
@@ -9,11 +9,11 @@ const animationConfig = {
   imageSequence: {
     progressRange: [0, 1],
     input: [0, 0.95, 1],
-    output: [100, 100, 0],
+    output: [100, 100, 50],
   },
   scrollText1: {
     input: [0, 0.2, 0.25],
-    output: ["0%", "0%", "100%"],
+    output: ["0%", "0%", "-100%"],
   },
   scrollText2: {
     input: [0.3, 0.375, 0.525, 0.55],

--- a/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/intro/intro-module.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/intro/intro-module.tsx
@@ -11,7 +11,7 @@ const animationConfig = {
   imageSequence: {
     progressRange: [0, 1],
     input: [0, 0.95, 1],
-    output: [100, 100, 0],
+    output: [100, 100, 50],
   },
   scrollText1: {
     input: [0, 0.075, 0.225, 0.3],

--- a/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/portugal-fires/portugal-fires.tsx
+++ b/src/scripts/components/stories/story/scroll-story/story-x-fires/modules/portugal-fires/portugal-fires.tsx
@@ -10,7 +10,7 @@ const animationConfig = {
   imageSequence: {
     progressRange: [0.15, 1],
     input: [0, 0.95, 1],
-    output: [100, 100, 0],
+    output: [100, 100, 50],
   },
   scrollText1: {
     input: [0, 0.1, 0.15, 0.225, 0.3],

--- a/src/scripts/libs/image-sequence.ts
+++ b/src/scripts/libs/image-sequence.ts
@@ -11,6 +11,8 @@ export interface ImageSequenceManifest {
   height?: number | null;
 }
 
+export type ImageSequenceVariant = "landscape" | "portrait";
+
 export function getImageSequenceFrameIndex(
   progress: number,
   progressRange: [number, number],
@@ -45,6 +47,16 @@ export function getImageSequenceFrameSrc(
   return `${normalizedBasePath}/frame-${String(frameNumber).padStart(4, "0")}.webp`;
 }
 
-export function getImageSequenceManifestSrc(basePath: string): string {
-  return `${basePath.replace(/\/$/, "")}/image-sequence.json`;
+export function getImageSequenceBasePath(
+  basePath: string,
+  variant: ImageSequenceVariant,
+): string {
+  return `${basePath.replace(/\/$/, "")}/${variant}`;
+}
+
+export function getImageSequenceManifestSrc(
+  basePath: string,
+  variant: ImageSequenceVariant,
+): string {
+  return `${getImageSequenceBasePath(basePath, variant)}/image-sequence.json`;
 }

--- a/storage/stories/story-x-fires/story-x-fires-en.json
+++ b/storage/stories/story-x-fires/story-x-fires-en.json
@@ -10,7 +10,7 @@
     {
       "type": "intro",
       "imageSequence": {
-        "path": "assets/video-1-sequence"
+        "path": "assets/video-sequence-1"
       },
       "content": {
         "scrollText1": "Fire is a natural part of many ecosystems, clearing dead wood and stimulating new growth. Humans have always lived with fire, using it to manage land and wildlife and to clear forest and shrubs for agriculture",


### PR DESCRIPTION
We will receive all videos in landscape and portrait format. This makes the `imageSequenceScroll` handle landscape videos correctly. We will also have  two folders in gcp, "portrait" and "landscape" to load the correct dimensions depending on the screen 